### PR TITLE
feat: add built-in MCP server with search index

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "mkdnsite",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "gray-matter": "^4.0.3",
         "katex": "^0.16.38",
         "lucide-react": "^0.577.0",
@@ -19,6 +20,7 @@
         "remark-github-blockquote-alert": "^2.0.1",
         "remark-math": "^6.0.0",
         "shiki": "^3.0.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -38,11 +40,15 @@
 
     "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
     "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
 
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -114,11 +120,15 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -152,6 +162,8 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -159,6 +171,8 @@
     "builtins": ["builtins@5.1.0", "", { "dependencies": { "semver": "^7.0.0" } }, "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg=="],
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -190,6 +204,16 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
@@ -210,6 +234,8 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
@@ -219,6 +245,10 @@
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -239,6 +269,8 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -284,6 +316,16 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
+
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
@@ -296,11 +338,15 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -309,6 +355,10 @@
     "flatted": ["flatted@3.4.0", "", {}, "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -394,9 +444,15 @@
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
+    "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
+
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -411,6 +467,10 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -460,6 +520,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
     "is-set": ["is-set@2.0.3", "", {}, "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="],
@@ -484,6 +546,8 @@
 
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
+    "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
@@ -492,7 +556,9 @@
 
     "json-parse-better-errors": ["json-parse-better-errors@1.0.2", "", {}, "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="],
 
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -556,6 +622,10 @@
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
@@ -618,6 +688,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -627,6 +701,8 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "natural-compare-lite": ["natural-compare-lite@1.4.0", "", {}, "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
@@ -645,6 +721,8 @@
     "object.groupby": ["object.groupby@1.0.3", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2" } }, "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ=="],
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -670,6 +748,8 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
@@ -678,11 +758,15 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-conf": ["pkg-conf@4.0.0", "", { "dependencies": { "find-up": "^6.0.0", "load-json-file": "^7.0.0" } }, "sha512-7dmgi4UY4qk+4mj5Cd8v/GExPo0K+SlY+hulOSdfZ/T6jVH6//y7NtzZo5WrfhDBxuQ0jCa7fLZmNaNh7EWL/w=="],
 
@@ -694,9 +778,17 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
@@ -738,6 +830,8 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -745,6 +839,8 @@
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
@@ -754,17 +850,25 @@
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -787,6 +891,8 @@
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "standard-engine": ["standard-engine@15.1.0", "", { "dependencies": { "get-stdin": "^8.0.0", "minimist": "^1.2.6", "pkg-conf": "^3.1.0", "xdg-basedir": "^4.0.0" } }, "sha512-VHysfoyxFu/ukT+9v49d4BRXIokFRZuH3z1VRxzFArZdjSCFpro6rEIU3ji7e4AoAtuSfKBkiOmsrDqKW5ZSRw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -822,6 +928,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
@@ -837,6 +945,8 @@
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -868,7 +978,11 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -896,11 +1010,19 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "@typescript-eslint/utils/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
+
+    "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "eslint/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -936,11 +1058,15 @@
 
     "standard-engine/pkg-conf": ["pkg-conf@3.1.0", "", { "dependencies": { "find-up": "^3.0.0", "load-json-file": "^5.2.0" } }, "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ=="],
 
+    "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
     "@eslint/eslintrc/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "@typescript-eslint/utils/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
     "eslint-plugin-es/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@1.3.0", "", {}, "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="],
+
+    "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "eslint/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -182,6 +182,25 @@ mkdnsite --static ./static --custom-css-url /my-theme.css
 mkdnsite --no-builtin-css --custom-css-url /my-complete-theme.css
 ```
 
+## MCP server
+
+Controls the built-in [MCP (Model Context Protocol)](/docs/mcp) server.
+
+| Flag | Description |
+|------|-------------|
+| `--no-mcp` | Disable the built-in MCP server |
+| `--mcp-endpoint <path>` | Custom MCP endpoint path (default: `/mcp`) |
+
+```bash
+# Disable MCP (e.g. public-facing site)
+mkdnsite --no-mcp
+
+# Custom endpoint path
+mkdnsite --mcp-endpoint /api/mcp
+```
+
+---
+
 ## GitHub source
 
 Serve content from a public GitHub repository instead of a local directory.
@@ -387,6 +406,8 @@ Every CLI flag maps to a field in `mkdnsite.config.ts`. CLI flags take precedenc
 | `--font-body` | `theme.fonts.body` |
 | `--font-mono` | `theme.fonts.mono` |
 | `--font-heading` | `theme.fonts.heading` |
+| `--no-mcp` | `mcp.enabled` |
+| `--mcp-endpoint` | `mcp.endpoint` |
 | `--github` | `github.owner` + `github.repo` |
 | `--github-ref` | `github.ref` |
 | `--github-path` | `github.path` |

--- a/content/docs/configuration.md
+++ b/content/docs/configuration.md
@@ -405,6 +405,30 @@ client: {
 
 ---
 
+## `mcp`
+
+Built-in MCP (Model Context Protocol) server for AI agent access to your documentation.
+
+```typescript
+mcp: {
+  enabled: true,
+  endpoint: '/mcp'   // MCP server URL path
+}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `boolean` | `true` | Enable the built-in MCP server |
+| `endpoint` | `string` | `'/mcp'` | URL path for the MCP endpoint |
+
+When enabled, AI clients (Claude Desktop, Cursor, etc.) can connect at `http://localhost:3000/mcp` and use the built-in tools: `search_docs`, `get_page`, `list_pages`, and `get_nav`.
+
+CLI flags: `--no-mcp`, `--mcp-endpoint <path>`
+
+See the [MCP guide](/docs/mcp) for full details.
+
+---
+
 ## Complete example
 
 ```typescript

--- a/content/docs/mcp.md
+++ b/content/docs/mcp.md
@@ -1,0 +1,162 @@
+---
+title: MCP Server
+description: Built-in Model Context Protocol server for AI agent access to your documentation.
+order: 6
+---
+
+# MCP Server
+
+mkdnsite includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server. When enabled, AI clients — Claude Desktop, Cursor, Cline, and any other MCP-compatible tool — can connect directly to your documentation and search, browse, and read pages using structured tools.
+
+This is distinct from the `/llms.txt` endpoint (which is a static file for AI crawlers). MCP provides interactive, query-driven access.
+
+## Quick start
+
+The MCP server is enabled by default at `/mcp`. Start your docs server and connect your AI client:
+
+```bash
+mkdnsite ./content
+# MCP endpoint: http://localhost:3000/mcp
+```
+
+## Available tools
+
+### `search_docs`
+
+Full-text search across all documentation pages using a TF-IDF index with boosts for title, description, and tags.
+
+**Parameters:**
+- `query` (string, required) — search query
+- `limit` (number, optional, 1–50, default 10) — max results
+
+**Returns:** array of `{ title, slug, description, excerpt, score }`
+
+```
+search_docs("getting started")
+→ [{ title: "Getting Started", slug: "/docs/getting-started", excerpt: "…", score: 0.42 }]
+```
+
+### `get_page`
+
+Retrieve the full markdown content of a page by its slug.
+
+**Parameters:**
+- `slug` (string, required) — page slug (e.g. `/docs/getting-started`)
+
+**Returns:** markdown content with title and description header, or an error if not found.
+
+```
+get_page("/docs/configuration")
+→ "# Configuration\n> Complete reference...\n\nmkdnsite is configured via..."
+```
+
+### `list_pages`
+
+List all available documentation pages.
+
+**Parameters:** none
+
+**Returns:** array of `{ title, slug, description? }`
+
+### `get_nav`
+
+Get the full navigation tree structure.
+
+**Parameters:** none
+
+**Returns:** JSON nav tree (same structure as the sidebar).
+
+## Connecting from AI clients
+
+### Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "my-docs": {
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+### Cursor
+
+In Cursor settings → MCP → Add server:
+
+```json
+{
+  "name": "my-docs",
+  "url": "http://localhost:3000/mcp"
+}
+```
+
+### Generic MCP client
+
+The endpoint uses the [Streamable HTTP transport](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/#streamable-http) (stateless mode). Any MCP client that supports HTTP transport can connect at:
+
+```
+http://your-host:port/mcp
+```
+
+## Resources
+
+In addition to tools, each page is also exposed as an MCP **resource** at:
+
+```
+mkdnsite://pages/{slug}
+```
+
+MCP clients that support resource browsing can list and read pages directly.
+
+## Search index
+
+The search index is built lazily on the first MCP request and uses TF-IDF scoring with:
+
+- **3× boost** for title matches
+- **2× boost** for description matches
+- **2× boost** for tag matches
+- **Smoothed IDF** — single-document corpora still return results
+
+The index is rebuilt automatically when `/_refresh` is called (e.g. in watch mode).
+
+## Configuration
+
+```typescript
+mcp: {
+  enabled: true,       // true (default) or false
+  endpoint: '/mcp'     // URL path (default: /mcp)
+}
+```
+
+CLI flags:
+
+```bash
+mkdnsite --no-mcp                     # disable MCP
+mkdnsite --mcp-endpoint /api/mcp      # custom path
+```
+
+## Disabling MCP
+
+For public-facing production sites, you may want to disable MCP to avoid exposing your content source structure:
+
+```bash
+mkdnsite --no-mcp --no-llms-txt
+```
+
+Or in config:
+
+```typescript
+const config: Partial<MkdnSiteConfig> = {
+  mcp: { enabled: false },
+  llmsTxt: { enabled: false }
+}
+```
+
+## Runtime compatibility
+
+The MCP server uses `WebStandardStreamableHTTPServerTransport` from the MCP SDK, which relies on Web Standard APIs (`Request`, `Response`, `ReadableStream`). It works on **Bun** and **Node.js 22+**.
+
+Deno compatibility depends on whether `@modelcontextprotocol/sdk` loads correctly under Deno's npm compatibility layer — this is not yet verified.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "src"
   ],
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "gray-matter": "^4.0.3",
     "katex": "^0.16.38",
     "lucide-react": "^0.577.0",
@@ -60,7 +61,8 @@
     "remark-gfm": "^4.0.0",
     "remark-github-blockquote-alert": "^2.0.1",
     "remark-math": "^6.0.0",
-    "shiki": "^3.0.0"
+    "shiki": "^3.0.0",
+    "zod": "^4.3.6"
   },
   "ts-standard": {
     "project": "./tsconfig.json"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,15 @@ export function parseArgs (args: string[]): ParsedArgs {
       result.theme = { ...(result.theme as object ?? {}), showToc: false }
     } else if (arg === '--no-nav') {
       result.theme = { ...(result.theme as object ?? {}), showNav: false }
+    } else if (arg === '--no-mcp') {
+      result.mcp = { ...(result.mcp ?? {}), enabled: false }
+    } else if (arg === '--mcp-endpoint') {
+      const ep = args[++i]
+      if (ep == null || !ep.startsWith('/')) {
+        console.error('Error: --mcp-endpoint must start with / (e.g. /mcp)')
+        process.exit(1)
+      }
+      result.mcp = { ...(result.mcp ?? {}), endpoint: ep }
     } else if (arg === '--no-llms-txt') {
       result.llmsTxt = { enabled: false }
     } else if (arg === '--no-negotiate') {
@@ -161,6 +170,8 @@ function printHelp (): void {
     --no-reading-time     Disable reading time display
     --no-toc              Disable table of contents sidebar
     --no-nav              Disable navigation sidebar
+    --no-mcp              Disable the built-in MCP server
+    --mcp-endpoint <path> Custom MCP endpoint path (default: /mcp)
     --no-llms-txt         Disable /llms.txt generation
     --no-negotiate        Disable content negotiation
     --renderer <engine>   Renderer: portable (default) or bun-native (Bun only)

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -43,7 +43,11 @@ export const DEFAULT_CONFIG: MkdnSiteConfig = {
     math: true,
     search: true
   },
-  renderer: 'portable'
+  renderer: 'portable',
+  mcp: {
+    enabled: true,
+    endpoint: '/mcp'
+  }
 }
 
 /**
@@ -97,6 +101,7 @@ export function resolveConfig (
     },
     llmsTxt: { ...DEFAULT_CONFIG.llmsTxt, ...userConfig.llmsTxt },
     client: { ...DEFAULT_CONFIG.client, ...userConfig.client },
-    github: userConfig.github
+    github: userConfig.github,
+    mcp: { ...DEFAULT_CONFIG.mcp, ...userConfig.mcp }
   }
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -44,6 +44,17 @@ export interface MkdnSiteConfig {
 
   /** GitHub repository source (alternative to local contentDir) */
   github?: import('../content/types.ts').GitHubSourceConfig
+
+  /** MCP (Model Context Protocol) server configuration */
+  mcp: McpConfig
+}
+
+/** MCP (Model Context Protocol) server configuration */
+export interface McpConfig {
+  /** Enable the built-in MCP server (default: true) */
+  enabled: boolean
+  /** MCP endpoint path (default: '/mcp') */
+  endpoint?: string
 }
 
 /** OpenGraph / social sharing meta tag configuration */

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -7,6 +7,10 @@ import { negotiateFormat } from './negotiate/accept.ts'
 import { markdownHeaders, htmlHeaders, estimateTokens } from './negotiate/headers.ts'
 import { renderPage, render404 } from './render/page-shell.ts'
 import { generateLlmsTxt } from './discovery/llmstxt.ts'
+import { createSearchIndex } from './search/index.ts'
+import type { SearchIndex } from './search/index.ts'
+import { createMcpServer } from './mcp/server.ts'
+import { createMcpHandler } from './mcp/transport.ts'
 
 export interface HandlerOptions {
   source: ContentSource
@@ -29,6 +33,22 @@ export function createHandler (opts: HandlerOptions): (request: Request) => Prom
   const { source, renderer, config } = opts
 
   let llmsTxtCache: string | null = null
+  let mcpHandlerFn: ((req: Request) => Promise<Response>) | null = null
+  let mcpInitPromise: Promise<(req: Request) => Promise<Response>> | null = null
+  let searchIndex: SearchIndex | null = null
+
+  async function ensureMcpHandler (): Promise<(req: Request) => Promise<Response>> {
+    if (mcpInitPromise != null) return await mcpInitPromise
+    mcpInitPromise = (async () => {
+      const si = createSearchIndex()
+      await si.rebuild(source)
+      searchIndex = si
+      const mcpServer = createMcpServer({ source, searchIndex: si })
+      return createMcpHandler(mcpServer)
+    })()
+    mcpHandlerFn = await mcpInitPromise
+    return mcpHandlerFn
+  }
 
   return async function handler (request: Request): Promise<Response> {
     const url = new URL(request.url)
@@ -56,7 +76,21 @@ export function createHandler (opts: HandlerOptions): (request: Request) => Prom
     if (pathname === '/_refresh' && request.method === 'POST') {
       await source.refresh()
       llmsTxtCache = null
+      // Rebuild search index on refresh
+      if (searchIndex != null) {
+        await searchIndex.rebuild(source)
+      }
       return new Response('cache cleared', { status: 200 })
+    }
+
+    // ---- MCP endpoint ----
+    if (
+      config.mcp.enabled &&
+      (pathname === (config.mcp.endpoint ?? '/mcp') ||
+        pathname.startsWith((config.mcp.endpoint ?? '/mcp') + '/'))
+    ) {
+      const mcp = await ensureMcpHandler()
+      return await mcp(request)
     }
 
     // ---- Static files passthrough ----

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,3 +64,12 @@ export { generateLlmsTxt } from './discovery/llmstxt.ts'
 export type { DeploymentAdapter } from './adapters/types.ts'
 export { detectRuntime } from './adapters/types.ts'
 export { LocalAdapter } from './adapters/local.ts'
+
+// Search
+export { createSearchIndex } from './search/index.ts'
+export type { SearchIndex, SearchResult } from './search/index.ts'
+
+// MCP
+export { createMcpServer } from './mcp/server.ts'
+export { createMcpHandler } from './mcp/transport.ts'
+export type { McpConfig } from './config/schema.ts'

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,164 @@
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import type { ContentSource } from '../content/types.ts'
+import type { SearchIndex } from '../search/index.ts'
+
+export function createMcpServer (opts: {
+  source: ContentSource
+  searchIndex: SearchIndex
+}): McpServer {
+  const { source, searchIndex } = opts
+
+  const server = new McpServer({
+    name: 'mkdnsite',
+    version: '0.1.0'
+  })
+
+  // ─── Tool: search_docs ──────────────────────────────────────────────────────
+
+  server.tool(
+    'search_docs',
+    'Full-text search across all documentation pages',
+    {
+      query: z.string().describe('Search query'),
+      limit: z.number().min(1).max(50).optional().describe('Max results (default 10, max 50)')
+    },
+    async ({ query, limit }) => {
+      const results = searchIndex.search(query, limit ?? 10)
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(results.map(r => ({
+            title: r.title,
+            slug: r.slug,
+            description: r.description,
+            excerpt: r.excerpt,
+            score: Math.round(r.score * 1000) / 1000
+          })), null, 2)
+        }]
+      }
+    }
+  )
+
+  // ─── Tool: get_page ─────────────────────────────────────────────────────────
+
+  server.tool(
+    'get_page',
+    'Retrieve the full markdown content of a documentation page by slug',
+    {
+      slug: z.string().describe('Page slug (e.g. /docs/getting-started)')
+    },
+    async ({ slug }) => {
+      const page = await source.getPage(slug)
+      if (page == null) {
+        return {
+          isError: true,
+          content: [{
+            type: 'text' as const,
+            text: `Page not found: ${slug}`
+          }]
+        }
+      }
+
+      const lines: string[] = []
+      if (page.meta.title != null) lines.push(`# ${String(page.meta.title)}`)
+      if (page.meta.description != null) lines.push(`> ${String(page.meta.description)}`)
+      if (lines.length > 0) lines.push('')
+      lines.push(page.body)
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: lines.join('\n')
+        }]
+      }
+    }
+  )
+
+  // ─── Tool: list_pages ───────────────────────────────────────────────────────
+
+  server.tool(
+    'list_pages',
+    'List all available documentation pages',
+    {},
+    async () => {
+      const pages = await source.listPages()
+      const list = pages.map(p => ({
+        title: String(p.meta.title ?? p.slug),
+        slug: p.slug,
+        description: p.meta.description != null ? String(p.meta.description) : undefined
+      }))
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(list, null, 2)
+        }]
+      }
+    }
+  )
+
+  // ─── Tool: get_nav ──────────────────────────────────────────────────────────
+
+  server.tool(
+    'get_nav',
+    'Get the documentation navigation tree',
+    {},
+    async () => {
+      const nav = await source.getNavTree()
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(nav, null, 2)
+        }]
+      }
+    }
+  )
+
+  // ─── Resources: pages ───────────────────────────────────────────────────────
+
+  const pageTemplate = new ResourceTemplate(
+    'mkdnsite://pages/{slug}',
+    {
+      list: async () => {
+        const pages = await source.listPages()
+        return {
+          resources: pages.map(p => ({
+            uri: `mkdnsite://pages${p.slug}`,
+            name: String(p.meta.title ?? p.slug),
+            description: p.meta.description != null ? String(p.meta.description) : undefined,
+            mimeType: 'text/markdown'
+          }))
+        }
+      }
+    }
+  )
+
+  server.resource(
+    'page',
+    pageTemplate,
+    { mimeType: 'text/markdown' },
+    async (uri) => {
+      // uri.href = "mkdnsite://pages/docs/getting-started"
+      const rawSlug = uri.href.replace(/^mkdnsite:\/\/pages/, '')
+      const resolvedSlug = rawSlug === '' ? '/' : rawSlug
+      const page = await source.getPage(resolvedSlug)
+      if (page == null) {
+        return { contents: [] }
+      }
+      const lines: string[] = []
+      if (page.meta.title != null) lines.push(`# ${String(page.meta.title)}`)
+      if (page.meta.description != null) lines.push(`> ${String(page.meta.description)}`)
+      if (lines.length > 0) lines.push('')
+      lines.push(page.body)
+      return {
+        contents: [{
+          uri: uri.href,
+          mimeType: 'text/markdown',
+          text: lines.join('\n')
+        }]
+      }
+    }
+  )
+
+  return server
+}

--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -1,0 +1,29 @@
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+/**
+ * Creates a fetch-compatible handler that routes HTTP requests to the MCP server
+ * via the Web Standard Streamable HTTP transport.
+ *
+ * Uses stateless mode (no session management) — each request is independent.
+ * A single transport instance handles all concurrent requests.
+ */
+export function createMcpHandler (server: McpServer): (request: Request) => Promise<Response> {
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined // stateless mode
+  })
+
+  let connectPromise: Promise<void> | null = null
+
+  async function ensureConnected (): Promise<void> {
+    if (connectPromise == null) {
+      connectPromise = server.connect(transport)
+    }
+    await connectPromise
+  }
+
+  return async (request: Request): Promise<Response> => {
+    await ensureConnected()
+    return await transport.handleRequest(request)
+  }
+}

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,0 +1,246 @@
+import type { ContentPage, ContentSource } from '../content/types.ts'
+
+export interface SearchResult {
+  slug: string
+  title: string
+  description?: string
+  excerpt: string
+  score: number
+}
+
+export interface SearchIndex {
+  /** Add or update a page in the index */
+  index: (page: ContentPage) => void
+  /** Remove a page from the index */
+  remove: (slug: string) => void
+  /** Search for pages matching a query */
+  search: (query: string, limit?: number) => SearchResult[]
+  /** Rebuild the entire index from a content source */
+  rebuild: (source: ContentSource) => Promise<void>
+}
+
+interface DocEntry {
+  slug: string
+  title: string
+  description?: string
+  tags: string[]
+  titleTokens: string[]
+  descTokens: string[]
+  tagTokens: string[]
+  bodyTokens: string[]
+  body: string
+  termFreqs: Map<string, number>
+  totalTokens: number
+}
+
+export function createSearchIndex (): SearchIndex {
+  // inverted index: token → set of slugs
+  const posting = new Map<string, Set<string>>()
+  const docs = new Map<string, DocEntry>()
+
+  function addToPosting (token: string, slug: string): void {
+    let set = posting.get(token)
+    if (set == null) {
+      set = new Set()
+      posting.set(token, set)
+    }
+    set.add(slug)
+  }
+
+  function removeFromPosting (slug: string): void {
+    for (const set of posting.values()) {
+      set.delete(slug)
+    }
+  }
+
+  function index (page: ContentPage): void {
+    const slug = page.slug
+
+    // Remove any existing entry first
+    if (docs.has(slug)) removeFromPosting(slug)
+
+    const title = String(page.meta.title ?? '')
+    const description = page.meta.description != null ? String(page.meta.description) : undefined
+    const tags: string[] = Array.isArray(page.meta.tags)
+      ? (page.meta.tags as unknown[]).map(t => String(t))
+      : []
+
+    const titleTokens = tokenize(title)
+    const descTokens = description != null ? tokenize(description) : []
+    const tagTokens = tags.flatMap(t => tokenize(t))
+    const bodyTokens = tokenize(stripMarkdown(page.body))
+
+    // Boost: title 3x, description 2x, tags 2x
+    const allTokens = [
+      ...titleTokens, ...titleTokens, ...titleTokens,
+      ...descTokens, ...descTokens,
+      ...tagTokens, ...tagTokens,
+      ...bodyTokens
+    ]
+
+    const termFreqs = new Map<string, number>()
+    for (const t of allTokens) {
+      termFreqs.set(t, (termFreqs.get(t) ?? 0) + 1)
+    }
+
+    const entry: DocEntry = {
+      slug,
+      title,
+      description,
+      tags,
+      titleTokens,
+      descTokens,
+      tagTokens,
+      bodyTokens,
+      body: page.body,
+      termFreqs,
+      totalTokens: allTokens.length
+    }
+    docs.set(slug, entry)
+
+    // Update posting list
+    for (const token of termFreqs.keys()) {
+      addToPosting(token, slug)
+    }
+  }
+
+  function remove (slug: string): void {
+    if (!docs.has(slug)) return
+    removeFromPosting(slug)
+    docs.delete(slug)
+  }
+
+  function search (query: string, limit = 10): SearchResult[] {
+    const cappedLimit = Math.min(limit, 50)
+    const trimmed = query.trim()
+    if (trimmed === '') return []
+
+    const queryTokens = tokenize(trimmed)
+    if (queryTokens.length === 0) return []
+
+    const totalDocs = docs.size
+    if (totalDocs === 0) return []
+
+    // Gather candidate slugs (any posting list hit)
+    const candidates = new Set<string>()
+    for (const token of queryTokens) {
+      const set = posting.get(token)
+      if (set != null) {
+        for (const slug of set) candidates.add(slug)
+      }
+    }
+
+    const results: SearchResult[] = []
+
+    for (const slug of candidates) {
+      const entry = docs.get(slug)
+      if (entry == null) continue
+
+      let score = 0
+      for (const token of queryTokens) {
+        const tf = (entry.termFreqs.get(token) ?? 0) / (entry.totalTokens === 0 ? 1 : entry.totalTokens)
+        const docsWithTerm = posting.get(token)?.size ?? 0
+        if (docsWithTerm === 0) continue
+        // Smoothed IDF: log((N+1) / df) — avoids zero when N == df
+        const idf = Math.log((totalDocs + 1) / docsWithTerm)
+        score += tf * idf
+      }
+
+      if (score <= 0) continue
+
+      results.push({
+        slug,
+        title: entry.title,
+        description: entry.description,
+        excerpt: buildExcerpt(entry.body, queryTokens),
+        score
+      })
+    }
+
+    return results
+      .sort((a, b) => b.score - a.score)
+      .slice(0, cappedLimit)
+  }
+
+  async function rebuild (source: ContentSource): Promise<void> {
+    const pages = await source.listPages()
+    docs.clear()
+    for (const set of posting.values()) set.clear()
+    posting.clear()
+    for (const page of pages) {
+      if (page.meta.draft !== true) {
+        index(page)
+      }
+    }
+  }
+
+  return { index, remove, search, rebuild }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function tokenize (text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s'-]/g, ' ')
+    .split(/\s+/)
+    .map(t => t.replace(/^['-]+|['-]+$/g, ''))
+    .filter(t => t.length >= 2 && !STOP_WORDS.has(t))
+}
+
+function stripMarkdown (md: string): string {
+  return md
+    // Remove fenced code blocks
+    .replace(/```[\s\S]*?```/g, ' ')
+    // Remove inline code
+    .replace(/`[^`]+`/g, ' ')
+    // Remove headings (keep text)
+    .replace(/^#{1,6}\s+/gm, '')
+    // Remove images
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    // Remove links (keep text)
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    // Remove bold/italic markers
+    .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1')
+    // Remove blockquotes
+    .replace(/^>\s*/gm, '')
+    // Remove horizontal rules
+    .replace(/^[-*_]{3,}\s*$/gm, '')
+    // Remove HTML tags
+    .replace(/<[^>]+>/g, ' ')
+    // Collapse whitespace
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function buildExcerpt (body: string, queryTokens: string[]): string {
+  const plain = stripMarkdown(body)
+  const lower = plain.toLowerCase()
+
+  let bestPos = -1
+  for (const token of queryTokens) {
+    const pos = lower.indexOf(token)
+    if (pos !== -1) {
+      bestPos = pos
+      break
+    }
+  }
+
+  if (bestPos === -1) {
+    return plain.slice(0, 150).trim() + (plain.length > 150 ? '…' : '')
+  }
+
+  const start = Math.max(0, bestPos - 50)
+  const end = Math.min(plain.length, start + 150)
+  const excerpt = plain.slice(start, end).trim()
+  return (start > 0 ? '…' : '') + excerpt + (end < plain.length ? '…' : '')
+}
+
+const STOP_WORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+  'of', 'with', 'by', 'from', 'is', 'it', 'its', 'this', 'that', 'be',
+  'as', 'was', 'are', 'were', 'been', 'has', 'have', 'had', 'do', 'does',
+  'did', 'not', 'no', 'so', 'if', 'up', 'can', 'will', 'you', 'we', 'he',
+  'she', 'they', 'their', 'all', 'any', 'also', 'more', 'into', 'than',
+  'then', 'when', 'how', 'what', 'which', 'who', 'use', 'used', 'using'
+])

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'bun:test'
+import { createMcpServer } from '../src/mcp/server.ts'
+import { createSearchIndex } from '../src/search/index.ts'
+import type { ContentPage, ContentSource, NavNode } from '../src/content/types.ts'
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makePage (slug: string, title: string, body: string, desc?: string): ContentPage {
+  return {
+    slug,
+    sourcePath: slug.replace(/^\//, '') + '.md',
+    meta: { title, description: desc },
+    body,
+    raw: `---\ntitle: ${title}\n---\n\n${body}`
+  }
+}
+
+const PAGES: ContentPage[] = [
+  makePage('/', 'Home', 'Welcome to mkdnsite.', 'The Markdown-first web server.'),
+  makePage('/docs/getting-started', 'Getting Started', 'Install with: `bun add mkdnsite`', 'Quick start guide.'),
+  makePage('/docs/config', 'Configuration', 'Configure via mkdnsite.config.ts', 'Full configuration reference.')
+]
+
+const mockSource: ContentSource = {
+  async getPage (slug: string) {
+    return PAGES.find(p => p.slug === slug) ?? null
+  },
+  async getNavTree (): Promise<NavNode> {
+    return {
+      title: 'Root',
+      slug: '/',
+      order: 0,
+      isSection: true,
+      children: [
+        {
+          title: 'Docs',
+          slug: '/docs',
+          order: 1,
+          isSection: true,
+          children: [
+            { title: 'Getting Started', slug: '/docs/getting-started', order: 1, isSection: false, children: [] },
+            { title: 'Configuration', slug: '/docs/config', order: 2, isSection: false, children: [] }
+          ]
+        }
+      ]
+    }
+  },
+  async listPages () { return PAGES },
+  async refresh () {}
+}
+
+function buildServer (): ReturnType<typeof createMcpServer> {
+  const searchIndex = createSearchIndex()
+  for (const page of PAGES) searchIndex.index(page)
+  return createMcpServer({ source: mockSource, searchIndex })
+}
+
+// ─── Helper: call tool directly via server internals ─────────────────────────
+// McpServer exposes tools but doesn't have a direct programmatic call API.
+// We test tool logic by calling the underlying handlers via the registered tools.
+// The cleanest way without a full transport: use a stub transport that captures requests.
+
+interface ToolResult { content: Array<{ type: string, text: string }>, isError?: boolean }
+
+async function callTool (
+  server: ReturnType<typeof buildServer>,
+  name: string,
+  args: Record<string, unknown>
+): Promise<ToolResult> {
+  // _registeredTools is a plain object keyed by tool name; each entry has a .handler function
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const toolRegistry = (server as any)._registeredTools as Record<string, { handler: (args: unknown) => Promise<ToolResult> }>
+
+  if (toolRegistry == null || toolRegistry[name] == null) {
+    throw new Error(`Tool not registered: ${name}`)
+  }
+
+  return await toolRegistry[name].handler(args)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('MCP tools registration', () => {
+  it('registers search_docs, get_page, list_pages, get_nav tools', () => {
+    const server = buildServer()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tools = (server as any)._registeredTools as Record<string, unknown>
+    expect(tools.search_docs).toBeDefined()
+    expect(tools.get_page).toBeDefined()
+    expect(tools.list_pages).toBeDefined()
+    expect(tools.get_nav).toBeDefined()
+  })
+})
+
+describe('MCP tool: search_docs', () => {
+  it('returns search results for a query', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'search_docs', { query: 'configuration' })
+    expect(result.content).toHaveLength(1)
+    const parsed = JSON.parse(result.content[0].text)
+    expect(Array.isArray(parsed)).toBe(true)
+    const config = parsed.find((r: { slug: string }) => r.slug === '/docs/config')
+    expect(config).toBeDefined()
+  })
+
+  it('returns empty array for unmatched query', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'search_docs', { query: 'zyxwvutsrqponmlkjihgfedcba' })
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed).toEqual([])
+  })
+
+  it('respects limit parameter', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'search_docs', { query: 'mkdnsite', limit: 1 })
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.length).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('MCP tool: get_page', () => {
+  it('returns markdown content for a valid slug', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'get_page', { slug: '/' })
+    expect(result.isError).toBeFalsy()
+    expect(result.content[0].text).toContain('# Home')
+    expect(result.content[0].text).toContain('Welcome to mkdnsite.')
+  })
+
+  it('includes description in header when present', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'get_page', { slug: '/' })
+    expect(result.content[0].text).toContain('> The Markdown-first web server.')
+  })
+
+  it('returns error for non-existent slug', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'get_page', { slug: '/nonexistent' })
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('not found')
+  })
+})
+
+describe('MCP tool: list_pages', () => {
+  it('returns all pages', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'list_pages', {})
+    const parsed = JSON.parse(result.content[0].text)
+    expect(Array.isArray(parsed)).toBe(true)
+    expect(parsed.length).toBe(PAGES.length)
+  })
+
+  it('each entry has title, slug, and optional description', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'list_pages', {})
+    const parsed = JSON.parse(result.content[0].text)
+    for (const entry of parsed) {
+      expect(entry.slug).toBeDefined()
+      expect(entry.title).toBeDefined()
+    }
+    const home = parsed.find((e: { slug: string }) => e.slug === '/')
+    expect(home.description).toBe('The Markdown-first web server.')
+  })
+})
+
+describe('MCP tool: get_nav', () => {
+  it('returns navigation tree as JSON', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'get_nav', {})
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.slug).toBe('/')
+    expect(parsed.isSection).toBe(true)
+    expect(Array.isArray(parsed.children)).toBe(true)
+  })
+
+  it('nav tree has docs section with children', async () => {
+    const server = buildServer()
+    const result = await callTool(server, 'get_nav', {})
+    const parsed = JSON.parse(result.content[0].text)
+    const docs = parsed.children.find((c: { slug: string }) => c.slug === '/docs')
+    expect(docs).toBeDefined()
+    expect(docs.children.length).toBe(2)
+  })
+})

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'bun:test'
+import { createSearchIndex } from '../src/search/index.ts'
+import type { ContentPage, ContentSource, NavNode } from '../src/content/types.ts'
+
+function makePage (slug: string, title: string, body: string, opts: {
+  description?: string
+  tags?: string[]
+  draft?: boolean
+} = {}): ContentPage {
+  return {
+    slug,
+    sourcePath: `${slug.replace(/^\//, '')}.md`,
+    meta: {
+      title,
+      description: opts.description,
+      tags: opts.tags,
+      draft: opts.draft
+    },
+    body,
+    raw: `---\ntitle: ${title}\n---\n\n${body}`
+  }
+}
+
+const mockSource = (pages: ContentPage[]): ContentSource => ({
+  async getPage (slug: string) {
+    return pages.find(p => p.slug === slug) ?? null
+  },
+  async getNavTree (): Promise<NavNode> {
+    return { title: 'Root', slug: '/', order: 0, children: [], isSection: true }
+  },
+  async listPages () {
+    return pages.filter(p => p.meta.draft !== true)
+  },
+  async refresh () {}
+})
+
+describe('SearchIndex.search', () => {
+  it('returns empty array for empty query', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Alpha', 'Some content'))
+    expect(idx.search('')).toEqual([])
+    expect(idx.search('   ')).toEqual([])
+  })
+
+  it('finds page by title keyword', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Getting Started Guide', 'Installation and setup'))
+    const results = idx.search('getting started')
+    expect(results.length).toBeGreaterThan(0)
+    expect(results[0].slug).toBe('/a')
+  })
+
+  it('finds page by body keyword', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Config', 'Set the hostname and port for your server'))
+    const results = idx.search('hostname')
+    expect(results.length).toBeGreaterThan(0)
+    expect(results[0].slug).toBe('/a')
+  })
+
+  it('title matches score higher than body matches', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Authentication Guide', 'Various topics covered here'))
+    idx.index(makePage('/b', 'Overview', 'This page covers authentication configuration and setup'))
+    const results = idx.search('authentication')
+    expect(results.length).toBe(2)
+    expect(results[0].slug).toBe('/a') // title match ranked higher
+  })
+
+  it('description boost works', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Page A', 'Generic content', { description: 'Advanced caching configuration' }))
+    idx.index(makePage('/b', 'Page B', 'This page mentions caching briefly once in the body'))
+    const results = idx.search('caching')
+    expect(results[0].slug).toBe('/a') // description boost
+  })
+
+  it('tag boost works', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Page A', 'Some content', { tags: ['typescript', 'config'] }))
+    idx.index(makePage('/b', 'Page B', 'This page mentions typescript once in the body text here'))
+    const results = idx.search('typescript')
+    expect(results[0].slug).toBe('/a') // tag boost
+  })
+
+  it('returns results sorted by score descending', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'TypeScript Guide', 'Complete TypeScript reference and configuration'))
+    idx.index(makePage('/b', 'JavaScript Guide', 'TypeScript is mentioned once here'))
+    const results = idx.search('typescript')
+    expect(results[0].score).toBeGreaterThan(results[1].score)
+  })
+
+  it('excerpt contains matching context', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Config', 'This is a long document. It talks about configuring authentication tokens for your API service endpoints.'))
+    const results = idx.search('authentication')
+    expect(results.length).toBe(1)
+    expect(results[0].excerpt).toContain('authentication')
+  })
+
+  it('excerpt falls back to start of body when no match found in body', () => {
+    const idx = createSearchIndex()
+    // Title matches but body doesn't contain the word
+    const page = makePage('/a', 'Getting Started', 'This page explains setup procedures for new users.')
+    idx.index(page)
+    const results = idx.search('getting')
+    expect(results.length).toBe(1)
+    expect(results[0].excerpt.length).toBeGreaterThan(0)
+  })
+
+  it('limit parameter works', () => {
+    const idx = createSearchIndex()
+    for (let i = 0; i < 20; i++) {
+      idx.index(makePage(`/p${i}`, `Page ${i}`, `Documentation about configuration setup ${i}`))
+    }
+    const results = idx.search('configuration', 5)
+    expect(results.length).toBeLessThanOrEqual(5)
+  })
+
+  it('limit is capped at 50', () => {
+    const idx = createSearchIndex()
+    for (let i = 0; i < 60; i++) {
+      idx.index(makePage(`/p${i}`, `Page ${i}`, `Documentation about setup ${i}`))
+    }
+    const results = idx.search('setup', 100)
+    expect(results.length).toBeLessThanOrEqual(50)
+  })
+
+  it('special characters do not crash tokenizer', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Special <chars> & more', 'Content with $pecial chars! @mentions #tags.'))
+    expect(() => idx.search('special')).not.toThrow()
+    expect(() => idx.search('<script>')).not.toThrow()
+    expect(() => idx.search('')).not.toThrow()
+  })
+})
+
+describe('SearchIndex.remove', () => {
+  it('remove() makes page unsearchable', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Authentication', 'Login and token management'))
+    idx.remove('/a')
+    const results = idx.search('authentication')
+    expect(results.length).toBe(0)
+  })
+
+  it('remove() on non-existent slug is a no-op', () => {
+    const idx = createSearchIndex()
+    expect(() => idx.remove('/nonexistent')).not.toThrow()
+  })
+
+  it('re-indexing after remove updates search results', () => {
+    const idx = createSearchIndex()
+    idx.index(makePage('/a', 'Old Title', 'authentication docs'))
+    idx.remove('/a')
+    idx.index(makePage('/a', 'New Title', 'completely different content'))
+    const authResults = idx.search('authentication')
+    expect(authResults.length).toBe(0)
+    const newResults = idx.search('different')
+    expect(newResults.length).toBe(1)
+  })
+})
+
+describe('SearchIndex.rebuild', () => {
+  it('rebuild() indexes all non-draft pages', async () => {
+    const idx = createSearchIndex()
+    const pages = [
+      makePage('/a', 'Alpha', 'content about configuration'),
+      makePage('/b', 'Beta', 'another page about setup'),
+      makePage('/c', 'Draft Page', 'secret stuff', { draft: true })
+    ]
+    await idx.rebuild(mockSource(pages))
+    expect(idx.search('configuration').length).toBe(1)
+    expect(idx.search('setup').length).toBe(1)
+    expect(idx.search('secret').length).toBe(0) // draft excluded
+  })
+
+  it('rebuild() clears old index', async () => {
+    const idx = createSearchIndex()
+    const oldPages = [makePage('/old', 'Old Page', 'obsolete content')]
+    await idx.rebuild(mockSource(oldPages))
+    expect(idx.search('obsolete').length).toBe(1)
+
+    const newPages = [makePage('/new', 'New Page', 'fresh documentation')]
+    await idx.rebuild(mockSource(newPages))
+    expect(idx.search('obsolete').length).toBe(0) // old content gone
+    expect(idx.search('fresh').length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a built-in MCP (Model Context Protocol) server so AI agents can search, browse, and read documentation via standard MCP tools. Also introduces a TF-IDF search index that will power human search in #22.

Closes #5 (Phase 1 — tools + resources)

## MCP Endpoint

Available at `/mcp` by default (configurable via `--mcp-endpoint`). Disable with `--no-mcp`.

### Tools

| Tool | Description |
|------|-------------|
| `search_docs` | Full-text search with TF-IDF scoring, title/description/tag boosting |
| `get_page` | Retrieve full markdown content by slug |
| `list_pages` | List all available pages with metadata |
| `get_nav` | Get the navigation tree structure |

### Resources

Every page is available as an MCP resource at `mkdnsite://pages/{slug}` with `text/markdown` MIME type.

## Search Index

TF-IDF implementation in `src/search/index.ts`:
- **Tokenization**: lowercase, split on whitespace/punctuation, markdown syntax stripped
- **Scoring**: term frequency × smoothed inverse document frequency (`log((N+1)/df)`)
- **Boosting**: title 3×, description 2×, tags 2×
- **Excerpts**: ~150 chars around first match with ellipsis
- **Lazy init**: built on first MCP request, not at startup
- **Refresh-aware**: rebuilt on `POST /_refresh`

This index is the shared foundation for future human search (#22) — it just needs an HTTP endpoint + client UI on top.

## Connecting

```json
// Claude Desktop / Cursor config
{
  "mcpServers": {
    "my-docs": {
      "url": "http://localhost:3000/mcp"
    }
  }
}
```

## Files changed

| File | Change |
|------|--------|
| `src/search/index.ts` | TF-IDF search index (new) |
| `src/mcp/server.ts` | MCP server with 4 tools + resources (new) |
| `src/mcp/transport.ts` | Streamable HTTP transport wrapper (new) |
| `src/config/schema.ts` | `McpConfig` interface |
| `src/config/defaults.ts` | MCP defaults |
| `src/cli.ts` | `--no-mcp`, `--mcp-endpoint` flags |
| `src/handler.ts` | MCP route + lazy init with race-safe promise sharing |
| `src/index.ts` | New exports |
| `test/search.test.ts` | 17 search index tests (new) |
| `test/mcp.test.ts` | 11 MCP tool tests (new) |
| `content/docs/mcp.md` | MCP documentation page (new) |
| `content/docs/configuration.md` | MCP config section |
| `content/docs/cli.md` | MCP CLI flags + parity table |

## Checks
- **Lint:** ✅ Clean
- **TypeScript:** ✅ Clean
- **Tests:** ✅ 143/143 pass (28 new, 115 existing)
- **Code review:** ✅ Patton reviewed — PASS. MAJOR race condition fixed, all NITs addressed.

## Phase 2 (future)
MCP prompts (`summarize_docs`, `find_howto`) — tracked in #5.