### PR TITLE
feat: add favicon support with format detection and logo fallback

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,8 @@ export function parseArgs (args: string[]): ParsedArgs {
       result.site = { ...(result.site as object ?? {}), title: args[++i] }
     } else if (arg === '--url') {
       result.site = { ...(result.site as object ?? {}), url: args[++i] }
+    } else if (arg === '--favicon') {
+      result.site = { ...(result.site as object ?? {}), favicon: { src: args[++i] } }
     } else if (arg === '--og-image') {
       result.site = { ...(result.site as object ?? {}), og: { ...((result.site as Record<string, unknown>)?.og as object ?? {}), image: args[++i] } }
     } else if (arg === '--og-type') {
@@ -154,6 +156,7 @@ ${section('Site:')}
 ${flag('--title <text>', 'Site title')}
 ${flag('--url <url>', 'Base URL for absolute links')}
 ${flag('--preset <name>', 'Apply preset: docs or blog')}
+${flag('--favicon <path>', 'Favicon path or URL (.ico, .png, .svg)')}
 ${flag('--og-image <url>', 'Default OpenGraph image URL')}
 ${flag('--og-type <type>', 'website or article')}
 ${flag('--twitter-card <type>', 'summary or summary_large_image')}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -69,6 +69,12 @@ export interface OgConfig {
   twitterSite?: string
 }
 
+/** Favicon configuration */
+export interface FaviconConfig {
+  /** Path or URL to the favicon file (.ico, .png, .svg) */
+  src: string
+}
+
 export interface SiteConfig {
   title: string
   description?: string
@@ -76,6 +82,8 @@ export interface SiteConfig {
   lang?: string
   /** OpenGraph / social sharing meta tag configuration */
   og?: OgConfig
+  /** Favicon configuration */
+  favicon?: FaviconConfig
 }
 
 export interface ServerConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type {
   MkdnSiteConfig,
   SiteConfig,
   OgConfig,
+  FaviconConfig,
   ThemeConfig,
   NegotiationConfig,
   ClientConfig,

--- a/src/render/page-shell.ts
+++ b/src/render/page-shell.ts
@@ -85,6 +85,7 @@ export function renderPage (props: PageShellProps): string {
   ${description !== '' ? `<meta name="description" content="${esc(description)}">` : ''}
   ${buildOgTags(props)}
   <meta name="generator" content="mkdnsite">
+  ${buildFaviconTags(config)}
   ${config.client.math ? '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16/dist/katex.min.css" crossorigin="anonymous">' : ''}
   <style>${buildThemeCss(config)}</style>
   ${config.theme.customCssUrl != null ? `<link rel="stylesheet" href="${esc(config.theme.customCssUrl)}">` : ''}
@@ -247,6 +248,40 @@ function buildPrevNextHtml (nav: NavNode, currentSlug: string): string {
     : '<span></span>'
 
   return `<nav class="mkdn-prev-next" aria-label="Page navigation">${prevHtml}${nextHtml}</nav>`
+}
+
+function faviconMimeType (src: string): string {
+  const lower = src.toLowerCase().split('?')[0]
+  if (lower.endsWith('.svg')) return 'image/svg+xml'
+  if (lower.endsWith('.png')) return 'image/png'
+  if (lower.endsWith('.ico')) return 'image/x-icon'
+  // Default fallback
+  return 'image/x-icon'
+}
+
+function buildFaviconTags (config: MkdnSiteConfig): string {
+  // Resolve favicon src: explicit favicon config wins, then logo fallback (PNG/SVG only)
+  let src: string | undefined
+  if (config.site.favicon?.src != null) {
+    src = config.site.favicon.src
+  } else if (config.theme.logo?.src != null) {
+    const lower = config.theme.logo.src.toLowerCase().split('?')[0]
+    if (lower.endsWith('.svg') || lower.endsWith('.png')) {
+      src = config.theme.logo.src
+    }
+  }
+  if (src == null) return ''
+
+  const safeSrc = esc(src)
+  const type = faviconMimeType(src)
+  const lines: string[] = []
+
+  lines.push(`<link rel="icon" href="${safeSrc}" type="${type}">`)
+  // apple-touch-icon for PNG (requires raster image)
+  if (type === 'image/png') {
+    lines.push(`<link rel="apple-touch-icon" href="${safeSrc}">`)
+  }
+  return lines.join('\n  ')
 }
 
 function buildOgTags (props: PageShellProps): string {

--- a/test/favicon.test.ts
+++ b/test/favicon.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'bun:test'
+import { renderPage } from '../src/render/page-shell.ts'
+import { resolveConfig } from '../src/config/defaults.ts'
+import { parseArgs } from '../src/cli.ts'
+
+function render (opts: Record<string, unknown> = {}): string {
+  const config = resolveConfig(opts as never)
+  return renderPage({
+    config,
+    meta: { slug: 'test', title: 'Test', body: '' },
+    renderedContent: '',
+    currentSlug: 'test'
+  })
+}
+
+describe('favicon — CLI flag', () => {
+  it('--favicon sets site.favicon.src', () => {
+    const { config } = parseArgs(['--favicon', '/favicon.ico'])
+    const site = config.site as unknown as Record<string, unknown>
+    expect((site?.favicon as Record<string, unknown>)?.src).toBe('/favicon.ico')
+  })
+
+  it('--favicon with PNG path', () => {
+    const { config } = parseArgs(['--favicon', '/icons/logo.png'])
+    const site = config.site as unknown as Record<string, unknown>
+    expect((site?.favicon as Record<string, unknown>)?.src).toBe('/icons/logo.png')
+  })
+})
+
+describe('favicon — page shell rendering', () => {
+  it('emits no favicon link when not configured', () => {
+    const html = render({})
+    expect(html).not.toContain('rel="icon"')
+    expect(html).not.toContain('apple-touch-icon')
+  })
+
+  it('emits favicon link for .ico', () => {
+    const html = render({ site: { favicon: { src: '/favicon.ico' } } })
+    expect(html).toContain('<link rel="icon" href="/favicon.ico" type="image/x-icon">')
+    expect(html).not.toContain('apple-touch-icon')
+  })
+
+  it('emits favicon link for .png with apple-touch-icon', () => {
+    const html = render({ site: { favicon: { src: '/favicon.png' } } })
+    expect(html).toContain('<link rel="icon" href="/favicon.png" type="image/png">')
+    expect(html).toContain('<link rel="apple-touch-icon" href="/favicon.png">')
+  })
+
+  it('emits favicon link for .svg without apple-touch-icon', () => {
+    const html = render({ site: { favicon: { src: '/favicon.svg' } } })
+    expect(html).toContain('<link rel="icon" href="/favicon.svg" type="image/svg+xml">')
+    expect(html).not.toContain('apple-touch-icon')
+  })
+
+  it('handles external URL favicon', () => {
+    const html = render({ site: { favicon: { src: 'https://example.com/favicon.ico' } } })
+    expect(html).toContain('<link rel="icon" href="https://example.com/favicon.ico" type="image/x-icon">')
+  })
+
+  it('escapes special characters in favicon src', () => {
+    const html = render({ site: { favicon: { src: '/icons/icon&v2.svg' } } })
+    expect(html).toContain('href="/icons/icon&amp;v2.svg"')
+  })
+})
+
+describe('favicon — logo fallback', () => {
+  it('uses PNG logo as favicon when no explicit favicon configured', () => {
+    const html = render({ theme: { logo: { src: '/logo.png' } } })
+    expect(html).toContain('<link rel="icon" href="/logo.png" type="image/png">')
+    expect(html).toContain('<link rel="apple-touch-icon" href="/logo.png">')
+  })
+
+  it('uses SVG logo as favicon when no explicit favicon configured', () => {
+    const html = render({ theme: { logo: { src: '/logo.svg' } } })
+    expect(html).toContain('<link rel="icon" href="/logo.svg" type="image/svg+xml">')
+  })
+
+  it('does NOT use .ico logo as favicon fallback', () => {
+    const html = render({ theme: { logo: { src: '/logo.ico' } } })
+    expect(html).not.toContain('rel="icon"')
+  })
+
+  it('explicit favicon wins over logo fallback', () => {
+    const html = render({
+      site: { favicon: { src: '/favicon.svg' } },
+      theme: { logo: { src: '/logo.png' } }
+    })
+    expect(html).toContain('href="/favicon.svg"')
+    expect(html).not.toContain('href="/logo.png"')
+  })
+})
+
+describe('favicon — MIME type detection', () => {
+  it('detects svg+xml for .svg', () => {
+    const html = render({ site: { favicon: { src: '/f.svg' } } })
+    expect(html).toContain('type="image/svg+xml"')
+  })
+
+  it('detects image/png for .png', () => {
+    const html = render({ site: { favicon: { src: '/f.png' } } })
+    expect(html).toContain('type="image/png"')
+  })
+
+  it('detects image/x-icon for .ico', () => {
+    const html = render({ site: { favicon: { src: '/f.ico' } } })
+    expect(html).toContain('type="image/x-icon"')
+  })
+
+  it('ignores query strings when detecting type', () => {
+    const html = render({ site: { favicon: { src: '/f.png?v=2' } } })
+    expect(html).toContain('type="image/png"')
+  })
+
+  it('defaults to image/x-icon for unknown extension', () => {
+    const html = render({ site: { favicon: { src: '/favicon' } } })
+    expect(html).toContain('type="image/x-icon"')
+  })
+})


### PR DESCRIPTION
Closes #35

## Summary

Adds favicon support to mkdnsite with automatic format detection and smart logo fallback.

### New config option

```ts
// mkdnsite.config.ts
export default {
  site: {
    title: 'My Docs',
    favicon: { src: '/favicon.svg' }
  }
}
```

CLI: `--favicon /favicon.svg`

### Features

- **Format detection**: Automatically sets correct MIME type based on extension (`.svg` → `image/svg+xml`, `.png` → `image/png`, `.ico` → `image/x-icon`)
- **Apple touch icon**: Emits `<link rel="apple-touch-icon">` for PNG favicons (Apple doesn't support SVG touch icons)
- **Logo fallback**: If no favicon is explicitly configured but a logo is set with a `.png` or `.svg` src, the logo is automatically used as the favicon
- **External URLs**: Supports `http://` and `//` URLs as favicon sources
- **Query string handling**: Strips query params before extension detection (`/favicon.png?v=2` → `.png`)

### Files changed

- `src/config/schema.ts` — `FaviconConfig` interface, `site.favicon?` on `SiteConfig`
- `src/cli.ts` — `--favicon` flag + `printHelp()`
- `src/render/page-shell.ts` — `buildFaviconTags()` with MIME detection, logo fallback, apple-touch-icon
- `src/index.ts` — exports `FaviconConfig`
- `test/favicon.test.ts` — 17 tests

### Tests

188/188 passing. Reviewed by Patton — PASS, no blockers.