### PR TITLE
fix: move @types/picomatch to dependencies for downstream tsc

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "mkdnsite",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@types/picomatch": "^4.0.2",
         "gray-matter": "^4.0.3",
         "katex": "^0.16.38",
         "lucide-react": "^0.577.0",
@@ -25,7 +26,6 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "@types/picomatch": "^4.0.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "ts-standard": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@types/picomatch": "^4.0.2",
     "gray-matter": "^4.0.3",
     "katex": "^0.16.38",
     "lucide-react": "^0.577.0",
@@ -70,7 +71,6 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/picomatch": "^4.0.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "ts-standard": "^12.0.2",


### PR DESCRIPTION
## Problem

mkdnsite publishes raw `.ts` source files (not compiled). Consumers who import `filesystem.ts` or `github.ts` (e.g. via `import ... from 'mkdnsite'`) encounter `import picomatch from 'picomatch'` in those files. TypeScript needs `@types/picomatch` to resolve the types.

With `@types/picomatch` in `devDependencies`, it is not installed when mkdnsite is used as a library dependency, causing `tsc` failures in downstream projects.

## Fix

Moved `@types/picomatch` from `devDependencies` to `dependencies`. `picomatch` itself was already in `dependencies` — this just ensures its type declarations travel with it.