### PR TITLE
fix: ensure version.ts is generated in all release and CI pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate version
+        run: bun run version:generate
+
       - name: Lint
         run: bun run lint
 
@@ -48,6 +51,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate version
+        run: bun run version:generate
+
       - name: Verify CLI loads on Node
         # --experimental-strip-types lets Node run .ts files directly.
         # --help exits 0 after printing usage, confirming the module graph
@@ -71,6 +77,9 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Generate version
+        run: bun run version:generate
 
       - name: Verify types on Deno
         # --unstable-sloppy-imports allows Deno to resolve bare npm specifiers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate version
+        run: bun run version:generate
+
       - name: Lint
         run: bun run lint
 
@@ -75,6 +78,9 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Generate version
+        run: bun run version:generate
 
       - name: Build Linux x64
         run: bun build --compile --target=bun-linux-x64 src/cli.ts --outfile dist/mkdnsite-linux-x64

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+test/
+scripts/
+.github/
+content/
+static/
+Dockerfile
+*.config.ts
+tsconfig.json
+CLAUDE.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,17 @@ FROM oven/bun:latest AS build
 WORKDIR /app
 
 # Install dependencies first (cache layer)
+# Use --ignore-scripts to skip prepare (scripts/ not copied yet)
 COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --ignore-scripts
 
-# Copy source and compile (auto-detects target platform)
+# Copy source, scripts, and config
 COPY src/ src/
+COPY scripts/ scripts/
 COPY tsconfig.json ./
+
+# Generate version.ts from package.json, then compile
+RUN bun run version:generate
 RUN bun build --compile src/cli.ts --outfile /app/mkdnsite
 
 # ── Runtime stage ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Three issues with the git-ignored `src/version.ts` approach introduced in PR #61:

### 1. npm publish would exclude src/version.ts
npm uses `.gitignore` for publish filtering when no `.npmignore` exists. Since `src/version.ts` is in `.gitignore`, it would be excluded from the published package even though `"files": ["src"]` is set in `package.json`.

**Fix**: Added `.npmignore`. When `.npmignore` exists, npm uses it *instead of* `.gitignore`. `src/version.ts` is not listed in `.npmignore`, so it will be included in the published package.

### 2. Docker build would fail
`scripts/` wasn't copied before `bun install`, so the `prepare` script would fail. And `COPY src/` after install would overwrite the generated `version.ts` anyway.

**Fix**: 
- `bun install --ignore-scripts` (skip `prepare` until `scripts/` is available)
- `COPY scripts/ scripts/` after source copy
- Explicit `RUN bun run version:generate` before `bun build --compile`

### 3. CI could run with stale/missing version.ts
`prepare` runs on `bun install` but isn't guaranteed in all environments. Explicit `Generate version` steps added to all CI and release jobs.

**Fix**: Added `bun run version:generate` step after `bun install` in: `check`, `test-node`, `test-deno` (ci.yml) and `publish`, `build-binaries` (release.yml). Docker is handled by the Dockerfile itself.