### PR TITLE
fix: coerce frontmatter title to string in nav tree builders

### DIFF
--- a/src/content/filesystem.ts
+++ b/src/content/filesystem.ts
@@ -193,7 +193,7 @@ export class FilesystemSource implements ContentSource {
       try {
         const raw = await readFile(join(dir, name), 'utf-8')
         const parsed = parseFrontmatter(raw)
-        if (parsed.meta.title != null) dirTitle = parsed.meta.title
+        if (parsed.meta.title != null) dirTitle = String(parsed.meta.title)
         if (parsed.meta.order != null) dirOrder = parsed.meta.order
         break
       } catch {
@@ -233,7 +233,7 @@ export class FilesystemSource implements ContentSource {
         const slug = `${slugPrefix}${slugPrefix.endsWith('/') ? '' : '/'}${name}`
 
         children.push({
-          title: parsed.meta.title ?? titleCase(name),
+          title: parsed.meta.title != null ? String(parsed.meta.title) : titleCase(name),
           slug,
           order: parsed.meta.order ?? 999,
           children: [],

--- a/src/content/nav-builder.ts
+++ b/src/content/nav-builder.ts
@@ -88,7 +88,7 @@ export function buildNavTree (files: FileEntry[], rootTitle = 'Root'): NavNode {
 
     const dirPath = dirParts.join('/')
     const section = getOrCreateSection(sections, dirPath, root)
-    if (file.meta.title != null) section.title = file.meta.title as string
+    if (file.meta.title != null) section.title = String(file.meta.title)
     if (file.meta.order != null) section.order = file.meta.order as number
   }
 
@@ -105,7 +105,7 @@ export function buildNavTree (files: FileEntry[], rootTitle = 'Root'): NavNode {
     const name = fileName.replace(/\.md$/, '')
     const slugPath = file.path.replace(/\.md$/, '')
     const node: NavNode = {
-      title: file.meta.title != null ? file.meta.title as string : titleCase(name),
+      title: file.meta.title != null ? String(file.meta.title) : titleCase(name),
       slug: '/' + slugPath,
       order: file.meta.order != null ? file.meta.order as number : 999,
       children: [],

--- a/test/nav-builder-title-coercion.test.ts
+++ b/test/nav-builder-title-coercion.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for frontmatter title coercion in nav tree builders.
+ *
+ * YAML parsers return `title: 404` as the integer 404, not the string "404".
+ * Without coercion, `a.title.localeCompare(b.title)` crashes with:
+ *   TypeError: a2.title.localeCompare is not a function
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { buildNavTree } from '../src/content/nav-builder.ts'
+
+describe('buildNavTree — numeric frontmatter title coercion', () => {
+  test('numeric title (404) is coerced to string', () => {
+    const files = [
+      { path: 'error.md', meta: { title: 404 } }
+    ]
+    const tree = buildNavTree(files)
+    const node = tree.children[0]
+    expect(typeof node.title).toBe('string')
+    expect(node.title).toBe('404')
+  })
+
+  test('numeric title in section index is coerced to string', () => {
+    const files = [
+      { path: 'errors/index.md', meta: { title: 500 } },
+      { path: 'errors/not-found.md', meta: {} }
+    ]
+    const tree = buildNavTree(files)
+    const section = tree.children.find(n => n.isSection)
+    expect(section).toBeDefined()
+    expect(typeof section?.title).toBe('string')
+    expect(section?.title).toBe('500')
+  })
+
+  test('sorting does not crash when two files have numeric titles', () => {
+    const files = [
+      { path: 'b-page.md', meta: { title: 404 } },
+      { path: 'a-page.md', meta: { title: 200 } }
+    ]
+    // localeCompare crashes on numbers — this should no longer throw
+    expect(() => buildNavTree(files)).not.toThrow()
+    const tree = buildNavTree(files)
+    expect(tree.children).toHaveLength(2)
+    expect(tree.children.every(n => typeof n.title === 'string')).toBe(true)
+  })
+
+  test('sorting does not crash when mixing numeric and string titles', () => {
+    const files = [
+      { path: 'one.md', meta: { title: 1 } },
+      { path: 'two.md', meta: { title: 'Hello' } },
+      { path: 'three.md', meta: { title: 3 } }
+    ]
+    expect(() => buildNavTree(files)).not.toThrow()
+  })
+
+  test('string titles continue to work normally', () => {
+    const files = [
+      { path: 'guide.md', meta: { title: 'Getting Started' } }
+    ]
+    const tree = buildNavTree(files)
+    expect(tree.children[0].title).toBe('Getting Started')
+  })
+
+  test('null/missing title falls back to titleCase of filename', () => {
+    const files = [
+      { path: 'getting-started.md', meta: {} }
+    ]
+    const tree = buildNavTree(files)
+    expect(tree.children[0].title).toBe('Getting Started')
+  })
+
+  test('boolean title is coerced to string', () => {
+    const files = [
+      { path: 'draft.md', meta: { title: true } }
+    ]
+    const tree = buildNavTree(files)
+    expect(tree.children[0].title).toBe('true')
+  })
+})


### PR DESCRIPTION
## Bug

YAML parsers return bare numbers as integers. A file with:

```yaml
---
title: 404
---
```

produces `meta.title = 404` (number), not `"404"` (string). When the nav tree sorts nodes alphabetically with `a.title.localeCompare(b.title)`, numbers don't have `.localeCompare`, crashing with:

```
TypeError: a2.title.localeCompare is not a function
```

## Fix

Replace all unsafe `as string` casts and `??` short-circuits in the nav-building code with explicit `String()` coercion behind a `!= null` guard.

### `src/content/nav-builder.ts`
- Section title from index file: `file.meta.title as string` → `String(file.meta.title)`
- Leaf node title: same

### `src/content/filesystem.ts`
- Directory title from index file: added `String()` coercion
- Leaf file title: `parsed.meta.title ?? titleCase(name)` → explicit `!= null` ternary with `String()` (avoids `String(undefined)` → `'undefined'`)

## Tests

`test/nav-builder-title-coercion.test.ts` (+7 tests, 415 total, 0 fail):
- Numeric title 404 coerced to `'404'`
- Numeric section index title coerced to string
- Sorting two numeric titles doesn't crash
- Mixing numeric and string titles doesn't crash
- String titles still work
- Missing title falls back to titleCase of filename
- Boolean title coerced to string