### PR TITLE
fix: strip .md extension from relative links in rendered HTML

### DIFF
--- a/src/render/components/index.ts
+++ b/src/render/components/index.ts
@@ -44,12 +44,56 @@ function Heading ({ children, id, level }: HeadingProps): React.ReactElement {
 }
 
 /**
+ * Strip the .md extension from a relative link href so that generated HTML
+ * links to the canonical URL mkdnsite serves (without .md).
+ *
+ * Rules:
+ * - Only transforms relative hrefs (not http/https/# links).
+ * - index.md / README.md / readme.md → strip filename, keep trailing slash.
+ * - other-page.md → other-page (anchor and query string preserved).
+ * - Leaves absolute URLs and anchor-only links unchanged.
+ */
+export function stripMdExtension (href: string): string {
+  // Leave absolute URLs and anchor-only links alone
+  if (
+    href.startsWith('http://') ||
+    href.startsWith('https://') ||
+    href.startsWith('#')
+  ) return href
+
+  // Split off any anchor (#...) or query string (?...) suffix
+  const hashIdx = href.indexOf('#')
+  const queryIdx = href.indexOf('?')
+  let splitIdx = -1
+  if (hashIdx !== -1 && queryIdx !== -1) splitIdx = Math.min(hashIdx, queryIdx)
+  else if (hashIdx !== -1) splitIdx = hashIdx
+  else if (queryIdx !== -1) splitIdx = queryIdx
+
+  const path = splitIdx !== -1 ? href.slice(0, splitIdx) : href
+  const suffix = splitIdx !== -1 ? href.slice(splitIdx) : ''
+
+  // index.md / README.md / readme.md → keep directory path with trailing slash
+  if (/(?:^|\/)(?:index|README|readme)\.md$/.test(path)) {
+    const dir = path.replace(/(?:index|README|readme)\.md$/, '')
+    return (dir === '' ? './' : dir) + suffix
+  }
+
+  // Any other .md file → strip extension
+  if (path.endsWith('.md')) {
+    return path.slice(0, -3) + suffix
+  }
+
+  return href
+}
+
+/**
  * Default link component with external link detection.
  */
 function Link ({ children, href, title }: LinkProps): React.ReactElement {
-  const isExternal = href?.startsWith('http://') === true || href?.startsWith('https://') === true
+  const resolvedHref = href != null ? stripMdExtension(href) : href
+  const isExternal = resolvedHref?.startsWith('http://') === true || resolvedHref?.startsWith('https://') === true
   const props: Record<string, unknown> = {
-    href,
+    href: resolvedHref,
     title,
     className: 'mkdn-link'
   }

--- a/test/link-md-strip.test.ts
+++ b/test/link-md-strip.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for stripMdExtension — strips .md from relative links in rendered HTML.
+ *
+ * mkdnsite serves pages at /path/to/page (no .md extension). Markdown files
+ * that contain relative links like [see this](./other-page.md) would produce
+ * broken hrefs without this transformation.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { stripMdExtension } from '../src/render/components/index.ts'
+
+describe('stripMdExtension — relative .md links', () => {
+  test('strips .md from a simple relative link', () => {
+    expect(stripMdExtension('./other-page.md')).toBe('./other-page')
+  })
+
+  test('strips .md from a parent-relative link', () => {
+    expect(stripMdExtension('../docs/setup.md')).toBe('../docs/setup')
+  })
+
+  test('strips .md from a bare relative path', () => {
+    expect(stripMdExtension('docs/setup.md')).toBe('docs/setup')
+  })
+
+  test('strips .md and preserves anchor', () => {
+    expect(stripMdExtension('./page.md#section')).toBe('./page#section')
+  })
+
+  test('strips .md and preserves query string', () => {
+    expect(stripMdExtension('./page.md?ref=main')).toBe('./page?ref=main')
+  })
+
+  test('strips .md and preserves both anchor and query string', () => {
+    expect(stripMdExtension('./page.md?ref=main#heading')).toBe('./page?ref=main#heading')
+  })
+})
+
+describe('stripMdExtension — index/README files', () => {
+  test('index.md in a directory becomes a trailing slash', () => {
+    expect(stripMdExtension('docs/index.md')).toBe('docs/')
+  })
+
+  test('./docs/index.md becomes ./docs/', () => {
+    expect(stripMdExtension('./docs/index.md')).toBe('./docs/')
+  })
+
+  test('bare index.md becomes ./', () => {
+    expect(stripMdExtension('index.md')).toBe('./')
+  })
+
+  test('README.md in a directory becomes a trailing slash', () => {
+    expect(stripMdExtension('docs/README.md')).toBe('docs/')
+  })
+
+  test('readme.md (lowercase) in a directory becomes a trailing slash', () => {
+    expect(stripMdExtension('docs/readme.md')).toBe('docs/')
+  })
+
+  test('index.md with anchor', () => {
+    expect(stripMdExtension('docs/index.md#overview')).toBe('docs/#overview')
+  })
+})
+
+describe('stripMdExtension — absolute URLs are unchanged', () => {
+  test('https URL with .md is not modified', () => {
+    expect(stripMdExtension('https://example.com/file.md')).toBe('https://example.com/file.md')
+  })
+
+  test('http URL with .md is not modified', () => {
+    expect(stripMdExtension('http://example.com/file.md')).toBe('http://example.com/file.md')
+  })
+
+  test('https URL without .md is not modified', () => {
+    expect(stripMdExtension('https://example.com/page')).toBe('https://example.com/page')
+  })
+})
+
+describe('stripMdExtension — anchor-only links are unchanged', () => {
+  test('anchor-only link is not modified', () => {
+    expect(stripMdExtension('#section')).toBe('#section')
+  })
+
+  test('anchor with text is not modified', () => {
+    expect(stripMdExtension('#getting-started')).toBe('#getting-started')
+  })
+})
+
+describe('stripMdExtension — links without .md are unchanged', () => {
+  test('relative link without .md extension', () => {
+    expect(stripMdExtension('./other-page')).toBe('./other-page')
+  })
+
+  test('link to a .md-like directory (no file extension)', () => {
+    expect(stripMdExtension('./cmd')).toBe('./cmd')
+  })
+
+  test('empty string', () => {
+    expect(stripMdExtension('')).toBe('')
+  })
+})


### PR DESCRIPTION
Closes #68

## Problem

Markdown files often contain relative links like `[see this](./other-page.md)` or `[setup](docs/setup.md)`. mkdnsite serves pages at `/path/to/page` (no `.md` extension), so these links produce 404s in the rendered HTML.

## Solution

New `stripMdExtension(href)` helper in `src/render/components/index.ts`, applied in the `Link` component before rendering the `href` attribute.

### Transformation rules

| Input | Output |
|-------|--------|
| `./other-page.md` | `./other-page` |
| `../docs/setup.md` | `../docs/setup` |
| `./page.md#section` | `./page#section` |
| `./page.md?ref=main` | `./page?ref=main` |
| `docs/index.md` | `docs/` |
| `index.md` | `./` |
| `docs/README.md` | `docs/` |
| `https://example.com/file.md` | unchanged |
| `#anchor` | unchanged |

## Tests

+20 tests (435 total, 0 fail) covering all transformation rules, edge cases, and no-op cases.