### PR TITLE
fix: decode HTML entities in ToC heading text to prevent double-escaping

### DIFF
--- a/src/render/page-shell.ts
+++ b/src/render/page-shell.ts
@@ -201,13 +201,13 @@ function buildReadingTimeHtml (body: string): string {
   return `<span class="mkdn-reading-time">${minutes} min read</span>`
 }
 
-function buildTocHtml (renderedContent: string): string {
+export function buildTocHtml (renderedContent: string): string {
   const headingRegex = /<h([2-4])\s[^>]*?id="([^"]+)"[^>]*>([\s\S]+?)<\/h[2-4]>/g
   const headings: Array<{ level: number, id: string, text: string }> = []
 
   let match = headingRegex.exec(renderedContent)
   while (match !== null) {
-    const text = match[3].replace(/<[^>]+>/g, '').trim()
+    const text = decodeHtmlEntities(match[3].replace(/<[^>]+>/g, '').trim())
     headings.push({ level: parseInt(match[1], 10), id: match[2], text })
     match = headingRegex.exec(renderedContent)
   }
@@ -360,4 +360,20 @@ function esc (str: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
+}
+
+/**
+ * Decode HTML entities in a string that has already been through renderToString().
+ * Used before re-escaping with esc() to prevent double-escaping.
+ */
+function decodeHtmlEntities (str: string): string {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
 }

--- a/test/toc-escaping.test.ts
+++ b/test/toc-escaping.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for ToC double-escaping fix.
+ *
+ * renderedContent has already been through renderToString(), so heading text
+ * contains HTML entities like &amp; (already escaped). buildTocHtml() must
+ * decode those entities before re-escaping with esc(), otherwise &amp; becomes
+ * &amp;amp; in the ToC link text.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { buildTocHtml } from '../src/render/page-shell.ts'
+
+// Helper: build a minimal rendered HTML string with one heading
+function h (level: number, id: string, text: string): string {
+  return `<h${level} id="${id}" class="mkdn-heading mkdn-h${level}">${text}</h${level}>`
+}
+
+describe('buildTocHtml — HTML entity double-escaping', () => {
+  test('ampersand in heading appears as & not &amp;amp; in ToC', () => {
+    // renderToString already escaped & → &amp; in the rendered HTML
+    const rendered = h(2, 'foo-bar', 'Foo &amp; Bar')
+    const toc = buildTocHtml(rendered)
+    expect(toc).toContain('>Foo &amp; Bar<')
+    expect(toc).not.toContain('&amp;amp;')
+  })
+
+  test('double-quote in heading appears as &quot; not &amp;quot; in ToC', () => {
+    const rendered = h(2, 'say-hello', 'Say &quot;Hello&quot;')
+    const toc = buildTocHtml(rendered)
+    expect(toc).toContain('&quot;Hello&quot;')
+    expect(toc).not.toContain('&amp;quot;')
+  })
+
+  test('less-than in heading is handled correctly', () => {
+    const rendered = h(2, 'a-lt-b', 'A &lt; B')
+    const toc = buildTocHtml(rendered)
+    expect(toc).toContain('A &lt; B')
+    expect(toc).not.toContain('&amp;lt;')
+  })
+
+  test('greater-than in heading is handled correctly', () => {
+    const rendered = h(2, 'a-gt-b', 'A &gt; B')
+    const toc = buildTocHtml(rendered)
+    expect(toc).toContain('A &gt; B')
+    expect(toc).not.toContain('&amp;gt;')
+  })
+
+  test('apostrophe (&#39;) in heading is not double-escaped', () => {
+    const rendered = h(2, 'its-fine', 'It&#39;s Fine')
+    const toc = buildTocHtml(rendered)
+    // After decode → "It's Fine" → esc() → "It&#x27;s Fine" or keeps it as plain apostrophe
+    // The key check: no &#39; gets turned into &amp;#39; or &#amp;39;
+    expect(toc).not.toContain('&amp;#39;')
+    expect(toc).not.toContain('&#amp;')
+  })
+
+  test('numeric hex entity is decoded and re-escaped correctly', () => {
+    const rendered = h(2, 'my-heading', 'My &#x26; Heading')
+    const toc = buildTocHtml(rendered)
+    // &#x26; decodes to & then re-escapes to &amp;
+    expect(toc).toContain('My &amp; Heading')
+    expect(toc).not.toContain('&amp;amp;')
+    expect(toc).not.toContain('&#x26;')
+  })
+})
+
+describe('buildTocHtml — normal headings still work', () => {
+  test('plain heading text is included', () => {
+    const rendered = h(2, 'getting-started', 'Getting Started')
+    const toc = buildTocHtml(rendered)
+    expect(toc).toContain('>Getting Started<')
+  })
+
+  test('heading id is used for the anchor href', () => {
+    const rendered = h(2, 'my-section', 'My Section')
+    const toc = buildTocHtml(rendered)
+    expect(toc).toContain('href="#my-section"')
+  })
+
+  test('h2 h3 h4 all appear in the ToC', () => {
+    const rendered = [
+      h(2, 'sec-one', 'Section One'),
+      h(3, 'sec-two', 'Sub Section'),
+      h(4, 'sec-three', 'Deep Section')
+    ].join('\n')
+    const toc = buildTocHtml(rendered)
+    expect(toc).toContain('mkdn-toc-2')
+    expect(toc).toContain('mkdn-toc-3')
+    expect(toc).toContain('mkdn-toc-4')
+  })
+
+  test('h1 is not included in the ToC', () => {
+    const rendered = [
+      h(1, 'title', 'Page Title'),
+      h(2, 'intro', 'Introduction')
+    ].join('\n')
+    const toc = buildTocHtml(rendered)
+    expect(toc).not.toContain('href="#title"')
+    expect(toc).toContain('href="#intro"')
+  })
+
+  test('returns empty string when no headings', () => {
+    expect(buildTocHtml('<p>No headings here</p>')).toBe('')
+  })
+
+  test('strips inline HTML from heading text (e.g. anchor icon)', () => {
+    // Headings include an <a> anchor child from the Heading component
+    const rendered = h(2, 'my-heading', '<a href="#my-heading" class="mkdn-heading-anchor" aria-hidden="true"><svg/></a> My Heading')
+    const toc = buildTocHtml(rendered)
+    // ToC link text should be just the heading words, no inline SVG or nested anchor markup
+    expect(toc).toContain('>My Heading<')
+    // The SVG markup should not appear in the link text
+    expect(toc).not.toContain('<svg')
+  })
+})


### PR DESCRIPTION
Closes #69

## Bug

`buildTocHtml()` extracts heading text from the output of `renderToString()`, which has already escaped HTML entities. The function strips inline tags but then calls `esc()` again, producing double-escaped output:

| Heading contains | Before fix | After fix |
|---|---|---|
| `&` | `&amp;amp;` ❌ | `&amp;` ✅ |
| `"` | `&amp;quot;` ❌ | `&quot;` ✅ |
| `<` | `&amp;lt;` ❌ | `&lt;` ✅ |

## Fix

Added `decodeHtmlEntities()` helper in `src/render/page-shell.ts` that reverses standard HTML entities and numeric references (`&#NN;`, `&#xNN;`).

Applied after stripping inline tags and before `esc()`:
```typescript
// Before
const text = match[3].replace(/<[^>]+>/g, '').trim()
// After
const text = decodeHtmlEntities(match[3].replace(/<[^>]+>/g, '').trim())
```

Also exported `buildTocHtml` for direct unit testing.

## Tests

+12 tests (`test/toc-escaping.test.ts`, 427 total, 0 fail):
- All 5 HTML entities verified (ampersand, quotes, lt, gt, apostrophe)
- Numeric hex entity (`&#x26;`)
- Normal text unchanged
- h1 excluded from ToC; h2–h4 included
- Empty content → empty string
- Inline HTML stripped from heading text