### PR TITLE
docs: fix inaccuracies in configuration reference

### DIFF
--- a/content/docs/configuration.md
+++ b/content/docs/configuration.md
@@ -206,12 +206,13 @@ site: {
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `title` | `string` | `'mkdnsite'` | Site name, appears in `<title>` as `Page — Site` |
-| `description` | `string` | — | Meta description, also used in `/llms.txt` |
+| `description` | `string` | — | Meta description. Also used as the fallback description in `/llms.txt` when `llmsTxt.description` is not set. |
 | `url` | `string` | — | Base URL for absolute links and sitemaps |
 | `lang` | `string` | `'en'` | HTML `lang` attribute |
 | `og` | `OgConfig` | — | OpenGraph / social sharing configuration (see below) |
+| `favicon` | `{ src: string }` | — | Favicon path or URL (`.ico`, `.png`, `.svg`). `src` is the URL path or absolute URL. |
 
-CLI flags: `--title`, `--url`
+CLI flags: `--title`, `--url`, `--favicon <path>`
 
 ### `site.og` — OpenGraph / social meta tags
 
@@ -388,7 +389,7 @@ CLI flag: `--no-builtin-css`
 | `pageDate` | `boolean` | `false` | `--page-date` / `--no-page-date` | Render `date`/`updated` from frontmatter below page title |
 | `readingTime` | `boolean` | `false` | `--reading-time` / `--no-reading-time` | Show estimated reading time (238 wpm) |
 | `prevNext` | `boolean` | `false` | `--prev-next` / `--no-prev-next` | Show prev/next page navigation links at bottom |
-| `editUrl` | `string` | — | — | Edit URL template, e.g. `https://github.com/org/repo/edit/main/{path}` |
+| `editUrl` | `string` | — | — | Edit URL template, e.g. `https://github.com/org/repo/edit/main/{path}` *(Planned — not yet implemented)* |
 | `syntaxTheme` | `string` | `'github-light'` | — | Shiki light mode syntax theme |
 | `syntaxThemeDark` | `string` | `'github-dark'` | — | Shiki dark mode syntax theme |
 
@@ -433,8 +434,12 @@ llmsTxt: {
   enabled: true,
   description: 'Documentation for my project.',
   sections: {
-    'API Reference': 'Detailed API documentation',
-    'Guides': 'Step-by-step tutorials'
+    // Keys are the first path segment of each page's URL (i.e. the top-level
+    // directory name). Values are the section heading to use in /llms.txt.
+    // Without this override, section headings are derived from the directory
+    // name via title-case (e.g. 'docs' → 'Docs').
+    'docs': 'API Reference',   // /docs/* pages → "## API Reference"
+    'guides': 'Tutorials'      // /guides/* pages → "## Tutorials"
   }
 }
 ```
@@ -442,8 +447,8 @@ llmsTxt: {
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | `boolean` | `true` | Generate `/llms.txt` |
-| `description` | `string` | — | Site description in the file |
-| `sections` | `Record<string, string>` | — | Custom section headers and descriptions |
+| `description` | `string` | — | Description line in the file. Falls back to `site.description` when not set. |
+| `sections` | `Record<string, string>` | — | Map of top-level directory names (URL path segments) to custom section titles in `/llms.txt`. Keys must match the first segment of page URLs (e.g. `'docs'` for `/docs/*`). Values are the `##` heading label used in the output. |
 
 CLI flag: `--no-llms-txt`
 
@@ -557,8 +562,9 @@ const config: Partial<MkdnSiteConfig> = {
     syntaxThemeDark: 'github-dark',
     showNav: true,
     showToc: true,
-    prevNext: true,
-    editUrl: 'https://github.com/myorg/myproject/edit/main/content/{path}'
+    prevNext: true
+    // editUrl: 'https://github.com/myorg/myproject/edit/main/content/{path}'
+    // ↑ Planned — not yet implemented
   },
 
   negotiation: {


### PR DESCRIPTION
Closes #79

Audit of `content/docs/configuration.md` against source code. Four inaccuracies fixed.

## Changes

### 1. `site.description` — clarify `/llms.txt` fallback behaviour

The docs said *"also used in `/llms.txt`"* — implies it always appears there. Actually `llmstxt.ts` uses it only as a fallback:
```typescript
const desc = config.llmsTxt.description ?? config.site.description
```
Updated to: *"Also used as the fallback description in `/llms.txt` when `llmsTxt.description` is not set."*

### 2. `site.favicon` — add missing option

`site.favicon` is defined in `schema.ts` and has a `--favicon` CLI flag in `cli.ts`, but was entirely absent from the config docs. Added it to the site options table with the CLI flag.

### 3. `editUrl` — mark as planned, not yet implemented

`theme.editUrl` is defined in `schema.ts` but is never read or used anywhere else in the codebase. Added *(Planned — not yet implemented)* to the table row. Also commented out `editUrl` in the complete example to avoid implying it works.

### 4. `llmsTxt.sections` — fix key semantics and description

Previous example had human-readable titles as keys:
```typescript
sections: { 'API Reference': 'Detailed API documentation' }
```
But `llmstxt.ts` uses the key as the **URL directory name** (first path segment of the page slug). The value is the section heading title. Corrected the example and rewrote the table description.