### PR TITLE
feat: always show home link in nav menu

### DIFF
--- a/src/render/page-shell.ts
+++ b/src/render/page-shell.ts
@@ -129,14 +129,23 @@ export function render404 (config: MkdnSiteConfig): string {
 
 function renderNavHeader (config: MkdnSiteConfig): string {
   const { logo, logoText } = config.theme
-  if (logo == null && (logoText == null || logoText === '')) return ''
 
   const imgHtml = logo != null
     ? `<span class="mkdn-nav-logo"><img src="${esc(logo.src)}" alt="${esc(logo.alt ?? '')}" width="${logo.width ?? 32}" height="${logo.height ?? 32}"></span>`
     : ''
-  const textHtml = logoText != null && logoText !== ''
-    ? `<span class="mkdn-nav-title">${esc(logoText)}</span>`
-    : ''
+
+  // Determine text label for the header link.
+  // - logoText is configured → use it
+  // - logo configured but no logoText → no text (image serves as link)
+  // - neither logo nor logoText → fall back to site title, then "Home",
+  //   so the nav always has a clickable home link even with minimal config.
+  let textHtml = ''
+  if (logoText != null && logoText !== '') {
+    textHtml = `<span class="mkdn-nav-title">${esc(logoText)}</span>`
+  } else if (logo == null) {
+    const fallback = config.site.title !== '' ? config.site.title : 'Home'
+    textHtml = `<span class="mkdn-nav-title">${esc(fallback)}</span>`
+  }
 
   return `<a href="/" class="mkdn-nav-header">${imgHtml}${textHtml}</a>`
 }

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -154,6 +154,32 @@ describe('renderPage', () => {
     expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
   })
 
+  it('renders site title as home link when no logo or logoText configured', () => {
+    const config = resolveConfig({ site: { title: 'My Docs' } })
+    const html = renderPage({ renderedContent: '', meta: baseMeta, config, nav: rootNav, currentSlug: '/' })
+    expect(html).toContain('class="mkdn-nav-header"')
+    expect(html).toContain('href="/"')
+    expect(html).toContain('<span class="mkdn-nav-title">My Docs</span>')
+  })
+
+  it('renders "Home" as home link when no logo, logoText, or site title configured', () => {
+    const config = resolveConfig({ site: { title: '' } })
+    const html = renderPage({ renderedContent: '', meta: baseMeta, config, nav: rootNav, currentSlug: '/' })
+    expect(html).toContain('class="mkdn-nav-header"')
+    expect(html).toContain('href="/"')
+    expect(html).toContain('<span class="mkdn-nav-title">Home</span>')
+  })
+
+  it('renders logo-only nav header without extra text when logo set but no logoText', () => {
+    const config = makeConfig({ logo: { src: '/logo.png', alt: 'Logo' } })
+    const html = renderPage({ renderedContent: '', meta: baseMeta, config, nav: rootNav, currentSlug: '/' })
+    expect(html).toContain('class="mkdn-nav-header"')
+    expect(html).toContain('href="/"')
+    expect(html).toContain('<img src="/logo.png"')
+    // No extra fallback text — image alone is the home link
+    expect(html).not.toContain('<span class="mkdn-nav-title">')
+  })
+
   it('emits customCssUrl as a <link rel="stylesheet"> tag', () => {
     const config = makeConfig({ customCssUrl: 'https://example.com/theme.css' })
     const html = renderPage({ renderedContent: '', meta: baseMeta, config, currentSlug: '/' })


### PR DESCRIPTION
Closes #70

## Problem

When neither `logo` nor `logoText` is configured, `renderNavHeader()` returned an empty string — no link to `/` in the nav sidebar. New projects and minimal configs had no way to navigate back to the home page from the sidebar.

## Fix

`src/render/page-shell.ts` — `renderNavHeader()`:

| Config | Before | After |
|--------|--------|-------|
| `logoText` set | text link | text link (unchanged) |
| `logo` set, no `logoText` | image link | image link (unchanged) |
| neither set | empty string ❌ | site title link ✅ |
| neither + no title | empty string ❌ | "Home" link ✅ |

Nav header now always renders an `<a href="/">`. When neither logo nor logoText is configured, falls back to `config.site.title`, then `'Home'` as a last resort.

## Tests

+3 tests in `test/theme.test.ts` (457 total, 0 fail):
- Site title renders as home link when no logo/logoText
- "Home" renders when no logo, logoText, or site title
- Logo-only case still has no extra text span