### PR TITLE
feat: add syntaxHighlight config with client-side Prism.js support

### DIFF
--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -31,10 +31,11 @@ export class LocalAdapter implements DeploymentAdapter {
   }
 
   async createRenderer (config: MkdnSiteConfig): Promise<MarkdownRenderer> {
+    const useServerHighlight = config.client.syntaxHighlight === 'server'
     const renderer = await createRenderer({
       engine: config.renderer,
-      syntaxTheme: config.theme.syntaxTheme,
-      syntaxThemeDark: config.theme.syntaxThemeDark,
+      syntaxTheme: useServerHighlight ? config.theme.syntaxTheme : undefined,
+      syntaxThemeDark: useServerHighlight ? config.theme.syntaxThemeDark : undefined,
       math: config.client.math
     })
     this.rendererEngine = renderer.engine

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -110,6 +110,15 @@ export function parseArgs (args: string[]): ParsedArgs {
       result.client = { ...(result.client as object ?? {}), search: false }
     } else if (arg === '--no-charts') {
       result.client = { ...(result.client as object ?? {}), charts: false }
+    } else if (arg === '--syntax-highlight') {
+      const mode = args[++i]
+      if (mode !== 'client' && mode !== 'server' && mode !== 'false') {
+        console.error("Error: --syntax-highlight must be 'client', 'server', or 'false'")
+        process.exit(1)
+      }
+      result.client = { ...(result.client as object ?? {}), syntaxHighlight: mode === 'false' ? false : mode }
+    } else if (arg === '--no-syntax-highlight') {
+      result.client = { ...(result.client as object ?? {}), syntaxHighlight: false }
     } else if (arg === '--color-scheme') {
       result.theme = { ...(result.theme as object ?? {}), colorScheme: args[++i] }
     } else if (arg === '--theme-mode') {
@@ -226,6 +235,8 @@ ${flag('--no-theme-toggle', 'Disable light/dark theme toggle')}
 ${flag('--no-math', 'Disable KaTeX math rendering')}
 ${flag('--no-search', 'Disable search (UI + /api/search)')}
 ${flag('--no-charts', 'Disable Chart.js chart rendering')}
+${flag('--syntax-highlight <mode>', 'Syntax highlighting: client (default), server (Shiki SSR), or false')}
+${flag('--no-syntax-highlight', 'Disable syntax highlighting entirely')}
 ${flag('--no-mcp', 'Disable built-in MCP server')}
 ${flag('--mcp-endpoint <path>', 'Custom MCP endpoint path (default: /mcp)')}
 ${flag('--no-llms-txt', 'Disable /llms.txt generation')}

--- a/src/client/scripts.ts
+++ b/src/client/scripts.ts
@@ -33,6 +33,10 @@ export function CLIENT_SCRIPTS (client: ClientConfig): string {
     scripts.push(CHART_SCRIPT)
   }
 
+  if (client.syntaxHighlight === 'client') {
+    scripts.push(PRISM_SCRIPT)
+  }
+
   if (scripts.length === 0) return ''
 
   return `<script>${scripts.join('\n')}</script>`
@@ -504,5 +508,45 @@ const CHART_SCRIPT = `
     });
   };
   document.head.appendChild(s);
+})();
+`.trim()
+
+const PRISM_SCRIPT = `
+(function(){
+  var codeBlocks = document.querySelectorAll('pre code[class*="language-"]');
+  if (codeBlocks.length === 0) return;
+  // Skip if Shiki already highlighted (contains spans with inline color styles)
+  var firstCode = codeBlocks[0];
+  if (firstCode.querySelector('span[style]')) return;
+  // Load Prism CSS — light or dark theme matching the current data-theme
+  var link = document.createElement('link');
+  link.rel = 'stylesheet';
+  var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+  link.href = isDark
+    ? 'https://cdn.jsdelivr.net/npm/prismjs@1/themes/prism-tomorrow.min.css'
+    : 'https://cdn.jsdelivr.net/npm/prismjs@1/themes/prism.min.css';
+  document.head.appendChild(link);
+  // Load Prism core, then autoloader for per-language grammar files
+  var s = document.createElement('script');
+  s.src = 'https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-core.min.js';
+  s.onload = function(){
+    var auto = document.createElement('script');
+    auto.src = 'https://cdn.jsdelivr.net/npm/prismjs@1/plugins/autoloader/prism-autoloader.min.js';
+    auto.onload = function(){ Prism.highlightAll(); };
+    document.head.appendChild(auto);
+  };
+  document.head.appendChild(s);
+  // Swap Prism theme when the user toggles light/dark mode
+  var observer = new MutationObserver(function(mutations){
+    mutations.forEach(function(m){
+      if (m.attributeName === 'data-theme') {
+        var dark = document.documentElement.getAttribute('data-theme') === 'dark';
+        link.href = dark
+          ? 'https://cdn.jsdelivr.net/npm/prismjs@1/themes/prism-tomorrow.min.css'
+          : 'https://cdn.jsdelivr.net/npm/prismjs@1/themes/prism.min.css';
+      }
+    });
+  });
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
 })();
 `.trim()

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -43,7 +43,8 @@ export const DEFAULT_CONFIG: MkdnSiteConfig = {
     themeToggle: true,
     math: true,
     search: true,
-    charts: true
+    charts: true,
+    syntaxHighlight: 'client'
   },
   renderer: 'portable',
   mcp: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -340,6 +340,15 @@ export interface ClientConfig {
 
   /** Enable Chart.js chart rendering (default: true when client enabled) */
   charts: boolean
+
+  /**
+   * Syntax highlighting engine.
+   * - 'client': load Prism.js from CDN at runtime (works everywhere, default)
+   * - 'server': use Shiki for SSR highlighting (WASM — not supported in CF Workers)
+   * - false: disable syntax highlighting entirely
+   * Default: 'client'
+   */
+  syntaxHighlight?: 'client' | 'server' | false
 }
 
 /**

--- a/test/syntax-highlight-config.test.ts
+++ b/test/syntax-highlight-config.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for theme.syntaxHighlight config option.
+ *
+ * - 'client' (default): Prism.js loaded from CDN at runtime
+ * - 'server': Shiki SSR (WASM-based, not for CF Workers)
+ * - false: no syntax highlighting
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { resolveConfig } from '../src/config/defaults.ts'
+import type { ClientConfig } from '../src/config/schema.ts'
+import { CLIENT_SCRIPTS } from '../src/client/scripts.ts'
+import { renderPage } from '../src/render/page-shell.ts'
+
+const rootNav = { title: 'root', slug: '/', order: 0, children: [], isSection: false }
+const baseMeta = { title: 'Test' }
+
+// ── Default ───────────────────────────────────────────────────────────────────
+
+describe('syntaxHighlight default', () => {
+  test("default is 'client'", () => {
+    const config = resolveConfig({})
+    expect(config.client.syntaxHighlight).toBe('client')
+  })
+})
+
+// ── CLIENT_SCRIPTS ────────────────────────────────────────────────────────────
+
+describe("CLIENT_SCRIPTS with syntaxHighlight: 'client'", () => {
+  test('includes Prism script', () => {
+    const config = resolveConfig({})
+    const scripts = CLIENT_SCRIPTS(config.client)
+    expect(scripts).toContain('prismjs')
+    expect(scripts).toContain('prism-core.min.js')
+    expect(scripts).toContain('prism-autoloader.min.js')
+  })
+
+  test('loads light theme CSS by default', () => {
+    const config = resolveConfig({})
+    const scripts = CLIENT_SCRIPTS(config.client)
+    expect(scripts).toContain('prism.min.css')
+  })
+
+  test('loads dark theme CSS for dark mode', () => {
+    const config = resolveConfig({})
+    const scripts = CLIENT_SCRIPTS(config.client)
+    expect(scripts).toContain('prism-tomorrow.min.css')
+  })
+
+  test('observer watches data-theme attribute changes', () => {
+    const config = resolveConfig({})
+    const scripts = CLIENT_SCRIPTS(config.client)
+    expect(scripts).toContain('data-theme')
+    expect(scripts).toContain('MutationObserver')
+  })
+})
+
+describe("CLIENT_SCRIPTS with syntaxHighlight: 'server'", () => {
+  test('does NOT include Prism script', () => {
+    const client: Partial<ClientConfig> = { syntaxHighlight: 'server' }
+    const config = resolveConfig({ client: client as ClientConfig })
+    const scripts = CLIENT_SCRIPTS(config.client)
+    expect(scripts).not.toContain('prismjs')
+    expect(scripts).not.toContain('prism-core.min.js')
+  })
+})
+
+describe('CLIENT_SCRIPTS with syntaxHighlight: false', () => {
+  test('does NOT include Prism script', () => {
+    const client: Partial<ClientConfig> = { syntaxHighlight: false }
+    const config = resolveConfig({ client: client as ClientConfig })
+    const scripts = CLIENT_SCRIPTS(config.client)
+    expect(scripts).not.toContain('prismjs')
+  })
+})
+
+// ── renderPage integration ────────────────────────────────────────────────────
+
+describe("renderPage with syntaxHighlight: 'client'", () => {
+  test('rendered HTML includes Prism CDN reference', () => {
+    const config = resolveConfig({})
+    const html = renderPage({ renderedContent: '<p>hi</p>', meta: baseMeta, config, nav: rootNav, currentSlug: '/' })
+    expect(html).toContain('prismjs')
+  })
+})
+
+describe("renderPage with syntaxHighlight: 'server'", () => {
+  test('rendered HTML does not include Prism', () => {
+    const client: Partial<ClientConfig> = { syntaxHighlight: 'server' }
+    const config = resolveConfig({ client: client as ClientConfig })
+    const html = renderPage({ renderedContent: '<p>hi</p>', meta: baseMeta, config, nav: rootNav, currentSlug: '/' })
+    expect(html).not.toContain('prismjs')
+  })
+})
+
+describe('renderPage with syntaxHighlight: false', () => {
+  test('rendered HTML does not include Prism', () => {
+    const client: Partial<ClientConfig> = { syntaxHighlight: false }
+    const config = resolveConfig({ client: client as ClientConfig })
+    const html = renderPage({ renderedContent: '<p>hi</p>', meta: baseMeta, config, nav: rootNav, currentSlug: '/' })
+    expect(html).not.toContain('prismjs')
+  })
+})


### PR DESCRIPTION
## Problem

Shiki uses WASM internally. WASM loading fails in Cloudflare Workers, so syntax highlighting has been silently broken for all mkdn.io hosted sites.

## Solution

New config option: `client.syntaxHighlight: 'client' | 'server' | false`

| Value | Description |
|-------|-------------|
| `'client'` (default) | Prism.js loaded lazily from CDN — works everywhere including CF Workers |
| `'server'` | Shiki SSR via WASM (previous opt-in behaviour) |
| `false` | No syntax highlighting |

```typescript
client: {
  syntaxHighlight: 'client'  // default — safe for CF Workers
  // syntaxHighlight: 'server'  // opt-in Shiki SSR (local/Node/Bun only)
  // syntaxHighlight: false     // disable entirely
}
```

CLI: `--syntax-highlight <client|server|false>` / `--no-syntax-highlight`

## Implementation

- **`src/client/scripts.ts`** — `PRISM_SCRIPT`: lazily loads `prism-core` + `autoloader` from jsDelivr, swaps light/dark Prism theme CSS on `data-theme` toggle via `MutationObserver`
- **`src/adapters/local.ts`** — only passes `syntaxTheme` to `createRenderer` when `syntaxHighlight === 'server'`; otherwise Shiki never initialises
- **Schema/defaults/CLI** wired as described

## Tests

`test/syntax-highlight-config.test.ts` — +10 tests (484 total, 0 fail)