### PR TITLE
fix: coerce esc() input to String to handle non-string frontmatter values

### DIFF
--- a/src/render/page-shell.ts
+++ b/src/render/page-shell.ts
@@ -361,8 +361,8 @@ function coerceDateToString (val: unknown): string {
   return String(val)
 }
 
-function esc (str: string): string {
-  return str
+function esc (str: unknown): string {
+  return String(str)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/test/esc-coerce.test.ts
+++ b/test/esc-coerce.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test'
+import { renderPage } from '../src/render/page-shell.ts'
+import { resolveConfig } from '../src/config/defaults.ts'
+
+describe('esc() coercion — non-string frontmatter values', () => {
+  it('should not crash when meta.title is a number', () => {
+    const config = resolveConfig({ site: { title: 'Test Site' } })
+    const html = renderPage({
+      renderedContent: '<p>hello</p>',
+      meta: { title: 404 as unknown as string },
+      config,
+      currentSlug: '/404'
+    })
+    expect(html).toContain('404')
+    expect(html).toContain('<title>404 — Test Site</title>')
+  })
+
+  it('should not crash when meta.description is a number', () => {
+    const config = resolveConfig({ site: { title: 'Test Site' } })
+    const html = renderPage({
+      renderedContent: '<p>hello</p>',
+      meta: { title: 'Page', description: 123 as unknown as string },
+      config,
+      currentSlug: '/test'
+    })
+    expect(html).toContain('123')
+  })
+
+  it('should handle boolean frontmatter values', () => {
+    const config = resolveConfig({ site: { title: 'Test Site' } })
+    const html = renderPage({
+      renderedContent: '<p>hello</p>',
+      meta: { title: true as unknown as string },
+      config,
+      currentSlug: '/test'
+    })
+    expect(html).toContain('true')
+  })
+})


### PR DESCRIPTION
Same root cause as #66 — YAML parses `title: 404` as a number. The `esc()` function in `page-shell.ts` assumed string input, crashing with `str.replace is not a function` when OG tags or page title tried to escape a numeric frontmatter value.

**Fix:** Change `esc(str: string)` to `esc(str: unknown)` with `String(str)` coercion. This protects all ~30 call sites in page-shell.ts.

3 tests covering numeric title, numeric description, and boolean title. 487/487 passing.