### PR TITLE
fix: cache nav tree in handler and expand favicon logo fallback

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { extname, basename } from 'node:path'
 import type { MkdnSiteConfig } from './config/schema.ts'
-import type { ContentSource } from './content/types.ts'
+import type { ContentSource, NavNode } from './content/types.ts'
 import type { MarkdownRenderer } from './render/types.ts'
 import { negotiateFormat } from './negotiate/accept.ts'
 import { markdownHeaders, htmlHeaders, estimateTokens } from './negotiate/headers.ts'
@@ -340,9 +340,19 @@ export function createHandler (opts: HandlerOptions): (request: Request) => Prom
       const custom404 = slug !== '/404' ? await source.getPage('/404') : null
       if (custom404 != null) {
         const renderedHtml = renderer.renderToHtml(custom404.body, config.theme.components)
-        const nav404 = (config.theme.showNav || config.theme.prevNext === true)
-          ? await source.getNavTree()
-          : undefined
+        let nav404: NavNode | undefined
+        if (config.theme.showNav || config.theme.prevNext === true) {
+          if (contentCache != null) {
+            const cached = await contentCache.getNav()
+            if (cached != null) nav404 = cached
+          }
+          if (nav404 == null) {
+            nav404 = await source.getNavTree()
+            if (contentCache != null && nav404 != null && nav404.children.length > 0) {
+              try { await contentCache.setNav(nav404) } catch { /* non-fatal */ }
+            }
+          }
+        }
         const html = renderPage({
           renderedContent: renderedHtml,
           meta: custom404.meta,
@@ -409,9 +419,19 @@ export function createHandler (opts: HandlerOptions): (request: Request) => Prom
 
     // ---- Render HTML via React SSR ----
     const renderedHtml = renderer.renderToHtml(page.body, config.theme.components)
-    const nav = (config.theme.showNav || config.theme.prevNext === true)
-      ? await source.getNavTree()
-      : undefined
+    let nav: NavNode | undefined
+    if (config.theme.showNav || config.theme.prevNext === true) {
+      if (contentCache != null) {
+        const cached = await contentCache.getNav()
+        if (cached != null) nav = cached
+      }
+      if (nav == null) {
+        nav = await source.getNavTree()
+        if (contentCache != null && nav != null && nav.children.length > 0) {
+          try { await contentCache.setNav(nav) } catch { /* non-fatal */ }
+        }
+      }
+    }
 
     const fullPage = renderPage({
       renderedContent: renderedHtml,

--- a/src/render/page-shell.ts
+++ b/src/render/page-shell.ts
@@ -281,6 +281,8 @@ function faviconMimeType (src: string): string {
   const lower = src.toLowerCase().split('?')[0]
   if (lower.endsWith('.svg')) return 'image/svg+xml'
   if (lower.endsWith('.png')) return 'image/png'
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg'
+  if (lower.endsWith('.webp')) return 'image/webp'
   if (lower.endsWith('.ico')) return 'image/x-icon'
   // Default fallback
   return 'image/x-icon'
@@ -293,7 +295,7 @@ function buildFaviconTags (config: MkdnSiteConfig): string {
     src = config.site.favicon.src
   } else if (config.theme.logo?.src != null) {
     const lower = config.theme.logo.src.toLowerCase().split('?')[0]
-    if (lower.endsWith('.svg') || lower.endsWith('.png')) {
+    if (lower.endsWith('.svg') || lower.endsWith('.png') || lower.endsWith('.jpg') || lower.endsWith('.jpeg') || lower.endsWith('.webp')) {
       src = config.theme.logo.src
     }
   }
@@ -304,8 +306,8 @@ function buildFaviconTags (config: MkdnSiteConfig): string {
   const lines: string[] = []
 
   lines.push(`<link rel="icon" href="${safeSrc}" type="${type}">`)
-  // apple-touch-icon for PNG (requires raster image)
-  if (type === 'image/png') {
+  // apple-touch-icon for raster images (PNG, JPEG, WebP)
+  if (type === 'image/png' || type === 'image/jpeg' || type === 'image/webp') {
     lines.push(`<link rel="apple-touch-icon" href="${safeSrc}">`)
   }
   return lines.join('\n  ')

--- a/test/favicon.test.ts
+++ b/test/favicon.test.ts
@@ -115,4 +115,39 @@ describe('favicon — MIME type detection', () => {
     const html = render({ site: { favicon: { src: '/favicon' } } })
     expect(html).toContain('type="image/x-icon"')
   })
+
+  it('detects image/jpeg for .jpg', () => {
+    const html = render({ site: { favicon: { src: '/f.jpg' } } })
+    expect(html).toContain('type="image/jpeg"')
+  })
+
+  it('detects image/jpeg for .jpeg', () => {
+    const html = render({ site: { favicon: { src: '/f.jpeg' } } })
+    expect(html).toContain('type="image/jpeg"')
+  })
+
+  it('detects image/webp for .webp', () => {
+    const html = render({ site: { favicon: { src: '/f.webp' } } })
+    expect(html).toContain('type="image/webp"')
+  })
+})
+
+describe('favicon — logo fallback extended formats', () => {
+  it('uses .jpg logo as favicon with apple-touch-icon', () => {
+    const html = render({ theme: { logo: { src: '/logo.jpg' } } })
+    expect(html).toContain('<link rel="icon" href="/logo.jpg" type="image/jpeg">')
+    expect(html).toContain('<link rel="apple-touch-icon" href="/logo.jpg">')
+  })
+
+  it('uses .jpeg logo as favicon with apple-touch-icon', () => {
+    const html = render({ theme: { logo: { src: '/logo.jpeg' } } })
+    expect(html).toContain('<link rel="icon" href="/logo.jpeg" type="image/jpeg">')
+    expect(html).toContain('<link rel="apple-touch-icon" href="/logo.jpeg">')
+  })
+
+  it('uses .webp logo as favicon with apple-touch-icon', () => {
+    const html = render({ theme: { logo: { src: '/logo.webp' } } })
+    expect(html).toContain('<link rel="icon" href="/logo.webp" type="image/webp">')
+    expect(html).toContain('<link rel="apple-touch-icon" href="/logo.webp">')
+  })
 })

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -7,6 +7,8 @@ import { createHandler } from '../src/handler.ts'
 import { FilesystemSource } from '../src/content/filesystem.ts'
 import { PortableRenderer } from '../src/render/portable.ts'
 import { resolveConfig } from '../src/config/defaults.ts'
+import { MemoryContentCache } from '../src/content/cache.ts'
+import type { NavNode } from '../src/content/types.ts'
 
 // ---- Content Negotiation ----
 
@@ -238,5 +240,79 @@ describe('staticHandler option', () => {
     const res = await handler(req)
     // No static handler, no staticDir — falls through to content routing → 404
     expect(res.status).toBe(404)
+  })
+})
+
+describe('nav contentCache', () => {
+  const config = resolveConfig({
+    contentDir: resolve(import.meta.dir, '../content'),
+    site: { title: 'Test Site' }
+  })
+  const renderer = new PortableRenderer()
+
+  it('stores nav in contentCache after first request', async () => {
+    const source = new FilesystemSource(config.contentDir)
+    const contentCache = new MemoryContentCache()
+
+    // Nav should not be cached yet
+    expect(await contentCache.getNav()).toBeNull()
+
+    const handler = createHandler({ source, renderer, config, contentCache })
+    await handler(new Request('http://localhost:3000/'))
+
+    // Nav should now be cached
+    const cached = await contentCache.getNav()
+    expect(cached).not.toBeNull()
+    expect(cached?.children.length).toBeGreaterThan(0)
+  })
+
+  it('serves nav from contentCache on subsequent requests (no getNavTree call)', async () => {
+    let getNavTreeCallCount = 0
+    const fakeNav: NavNode = {
+      title: 'cached-root',
+      slug: '/',
+      order: 0,
+      isSection: false,
+      children: [{ title: 'Cached Page', slug: '/cached', order: 1, isSection: false, children: [] }]
+    }
+
+    // Stub source with a spy on getNavTree
+    const source = new FilesystemSource(config.contentDir)
+    const origGetNavTree = source.getNavTree.bind(source)
+    source.getNavTree = async () => {
+      getNavTreeCallCount++
+      return await origGetNavTree()
+    }
+
+    const contentCache = new MemoryContentCache()
+    // Pre-populate cache with our fake nav
+    await contentCache.setNav(fakeNav)
+
+    const handler = createHandler({ source, renderer, config, contentCache })
+    const res = await handler(new Request('http://localhost:3000/'))
+    expect(res.status).toBe(200)
+
+    // getNavTree should NOT have been called because cache was warm
+    expect(getNavTreeCallCount).toBe(0)
+
+    // The rendered HTML should contain the cached nav label
+    const html = await res.text()
+    expect(html).toContain('Cached Page')
+  })
+
+  it('does not cache an empty nav tree', async () => {
+    // Source whose getNavTree returns empty nav
+    const emptySource = {
+      getPage: (new FilesystemSource(config.contentDir)).getPage.bind(new FilesystemSource(config.contentDir)),
+      getNavTree: async (): Promise<NavNode> => ({ title: '', slug: '/', order: 0, isSection: false, children: [] }),
+      listPages: async () => []
+    }
+
+    const contentCache = new MemoryContentCache()
+    const handler = createHandler({ source: emptySource as never, renderer, config, contentCache })
+    await handler(new Request('http://localhost:3000/'))
+
+    // Empty nav should not be cached
+    expect(await contentCache.getNav()).toBeNull()
   })
 })


### PR DESCRIPTION
## Nav caching

Fixes mkdnio#123. The nav tree was fetched via `source.getNavTree()` on every request without ever reading from `contentCache`. Now both the 404 and normal render paths:

1. Check `contentCache.getNav()` first (warm cache path)
2. Fall back to `source.getNavTree()` only on miss
3. Write to `contentCache.setNav()` after fetch (only when `nav.children.length > 0`)

Cache write is non-fatal (try/catch). Empty nav trees are never cached.

**3 new tests** covering: cache population, cache hit (getNavTree not called), empty nav not cached.

## Favicon logo fallback extensions

`buildFaviconTags()` previously only fell back to the site logo when it was `.svg` or `.png`. Now also handles `.jpg`, `.jpeg`, and `.webp`, with correct MIME types and `apple-touch-icon` for raster formats.

**6 new tests** covering MIME type detection and logo fallback for all three new formats.