### PR TITLE
fix: consume 401 response body before retry to prevent Workers deadlock

### DIFF
--- a/src/content/github.ts
+++ b/src/content/github.ts
@@ -244,6 +244,8 @@ export class GitHubSource implements ContentSource {
       // If token was provided but GitHub returned 401, the token may be
       // expired/revoked. Retry without auth — the repo may be public.
       if (response.status === 401 && token !== '') {
+        // Consume the response body to free the connection (required in Workers)
+        await response.text().catch(() => {})
         console.warn('GitHubSource: file fetch returned 401, retrying without auth')
         const retryHeaders: Record<string, string> = { 'User-Agent': `mkdnsite/${VERSION}` }
         const retryResp = await fetch(url, { headers: retryHeaders })
@@ -312,6 +314,8 @@ export class GitHubSource implements ContentSource {
       // If token was provided but GitHub returned 401, the token may be
       // expired/revoked. Retry without auth — the repo may be public.
       if (response.status === 401 && token !== '') {
+        // Consume the response body to free the connection (required in Workers)
+        await response.text().catch(() => {})
         console.warn('GitHubSource: tree API returned 401, retrying without auth')
         const retryHeaders: Record<string, string> = { ...GITHUB_HEADERS }
         try {


### PR DESCRIPTION
Fixes a Cloudflare Workers connection exhaustion bug introduced in PR #104.

## Problem

When `fetchFile()` or `fetchTreeOnce()` gets a 401 and retries without auth, the original 401 response body was left unconsumed. Workers limits concurrent in-flight responses — unconsumed bodies hold connections open, pile up under load, and get killed by the runtime, causing all subsequent file fetches to fail silently.

## Fix

Added `await response.text().catch(() => {})` before each retry to drain the 401 response body and free the connection.

Two places: `fetchFile()` and `fetchTreeOnce()`.

529/529 tests pass. Needs a new mkdnsite release so mkdnio can pick it up.