### PR TITLE
fix: display error message when Search API returns non-200 response

### DIFF
--- a/src/client/scripts.ts
+++ b/src/client/scripts.ts
@@ -210,15 +210,26 @@ const SEARCH_SCRIPT = `
     if (!q) { resultsEl.innerHTML = '<p class="mkdn-search-hint">Type to search\u2026</p>'; return; }
     resultsEl.innerHTML = '<p class="mkdn-search-hint mkdn-search-hint--loading">Searching\u2026</p>';
     var url = '/api/search?q=' + encodeURIComponent(q) + '&limit=10';
-    fetch(url).then(function(r){ return r.json(); }).then(function(results){
-      renderResults(results, q);
-    }).catch(function(){
+    fetch(url).then(function(r) {
+      if (!r.ok) {
+        return r.json().then(function(data) {
+          resultsEl.innerHTML = '<p class="mkdn-search-hint">' + escHtml(data.error || 'Search unavailable') + '</p>';
+          return null;
+        }).catch(function() {
+          resultsEl.innerHTML = '<p class="mkdn-search-hint">Search unavailable</p>';
+          return null;
+        });
+      }
+      return r.json();
+    }).then(function(results) {
+      if (results != null) renderResults(results, q);
+    }).catch(function() {
       resultsEl.innerHTML = '<p class="mkdn-search-hint">Search unavailable</p>';
     });
   }
 
   function renderResults(results, q) {
-    if (!results.length) {
+    if (!Array.isArray(results) || !results.length) {
       resultsEl.innerHTML = '<p class="mkdn-search-hint">No results found</p>';
       return;
     }


### PR DESCRIPTION
## Bug

When the Search API returns a 503 (e.g. `{"error":"Search index is building. Please try again in a few seconds."}`), the UI shows **"No results found"** instead of the actual error message.

**Root cause**: The client-side search script does:
```javascript
fetch(url).then(function(r){ return r.json(); }).then(function(results){
  renderResults(results, q);
})
```

A 503 response with valid JSON (`{error: "..."}`) passes through `r.json()` successfully. The result object is passed to `renderResults`, which checks `!results.length` — an object has no `.length` property, so `!undefined` is `true`, displaying "No results found".

Fixes #108

## Fix

1. **Check `r.ok` before treating response as results** — if non-200, extract the error message from the JSON body and display it to the user
2. **Add `Array.isArray()` guard in `renderResults`** — defensive check so non-array responses never slip through

The user now sees the actual error message (e.g. "Search index is building. Please try again in a few seconds.") instead of the misleading "No results found".