### PR TITLE
feat: fallback to random port when preferred port is occupied

### DIFF
--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -63,13 +63,14 @@ export class LocalAdapter implements DeploymentAdapter {
     handler: (request: Request) => Promise<Response>,
     config: MkdnSiteConfig
   ): () => void {
-    const server = Bun.serve({
-      port: config.server.port,
-      hostname: config.server.hostname,
-      fetch: handler
-    })
-
-    this.printStartup(config, server.port ?? config.server.port)
+    const { port: preferred, hostname } = config.server
+    let server: ReturnType<typeof Bun.serve>
+    try {
+      server = Bun.serve({ port: preferred, hostname, fetch: handler })
+    } catch {
+      server = Bun.serve({ port: 0, hostname, fetch: handler })
+    }
+    this.printStartup(config, server.port ?? preferred)
     return () => { void server.stop() }
   }
 
@@ -77,14 +78,21 @@ export class LocalAdapter implements DeploymentAdapter {
     handler: (request: Request) => Promise<Response>,
     config: MkdnSiteConfig
   ): () => void {
-    const { port, hostname } = config.server
+    const { port: preferred, hostname } = config.server
 
-    // Deno.serve is available globally in Deno
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const DenoNs = (globalThis as any).Deno
-    const server = DenoNs.serve({ port, hostname }, handler)
+    let server
+    try {
+      server = DenoNs.serve({ port: preferred, hostname }, handler)
+    } catch {
+      server = DenoNs.serve({ port: 0, hostname }, handler)
+    }
 
-    this.printStartup(config, port)
+    // Deno assigns the actual port on server.addr
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const actualPort: number = server.addr?.port ?? preferred
+    this.printStartup(config, actualPort)
     return () => { void server.shutdown() }
   }
 
@@ -92,11 +100,11 @@ export class LocalAdapter implements DeploymentAdapter {
     handler: (request: Request) => Promise<Response>,
     config: MkdnSiteConfig
   ): Promise<() => void> {
-    const { port, hostname } = config.server
+    const { port: preferred, hostname } = config.server
     const { createServer } = await import('node:http')
 
     const server = createServer((req, res) => {
-      const host = req.headers.host ?? `${hostname}:${String(port)}`
+      const host = req.headers.host ?? `${hostname}:${String(preferred)}`
       const url = new URL(req.url ?? '/', `http://${host}`)
 
       const headers = new Headers()
@@ -132,16 +140,43 @@ export class LocalAdapter implements DeploymentAdapter {
         })
     })
 
-    await new Promise<void>((resolve) => {
-      server.listen(port, hostname, () => { resolve() })
-    })
+    const actualPort = await this.listenOnPort(server, preferred, hostname)
 
-    this.printStartup(config, port)
+    this.printStartup(config, actualPort)
     return () => { server.close() }
   }
 
-  private printStartup (config: MkdnSiteConfig, port: number): void {
-    const url = `http://localhost:${String(port)}`
+  /**
+   * Try preferred port; on EADDRINUSE, let the OS pick one.
+   */
+  private listenOnPort (
+    server: import('node:http').Server,
+    preferred: number,
+    hostname: string
+  ): Promise<number> {
+    return new Promise((resolve, reject) => {
+      server.once('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          // Remove this error listener, retry with port 0
+          server.removeAllListeners('error')
+          server.listen(0, hostname, () => {
+            const addr = server.address()
+            resolve(typeof addr === 'object' && addr != null ? addr.port : preferred)
+          })
+          server.on('error', reject)
+        } else {
+          reject(err)
+        }
+      })
+      server.listen(preferred, hostname, () => {
+        const addr = server.address()
+        resolve(typeof addr === 'object' && addr != null ? addr.port : preferred)
+      })
+    })
+  }
+
+  private printStartup (config: MkdnSiteConfig, actualPort: number): void {
+    const url = `http://localhost:${String(actualPort)}`
     const DIM_CYAN = '\x1b[2;36m'
     const BOLD_GREEN = '\x1b[1;32m'
     const DIM = '\x1b[2m'
@@ -154,6 +189,9 @@ export class LocalAdapter implements DeploymentAdapter {
     console.log(`▌▌▌▛▖▙▌▌▌▄▌▌▐▖▙▖${RESET}`)
     console.log('')
     console.log(`  ${BOLD_GREEN}\u2192 ${url}${RESET}`)
+    if (actualPort !== config.server.port) {
+      console.log(`  ${DIM}Port ${String(config.server.port)} was in use, using ${String(actualPort)}${RESET}`)
+    }
     console.log('')
 
     const row = (label: string, value: string): void => {

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -67,7 +67,8 @@ export class LocalAdapter implements DeploymentAdapter {
     let server: ReturnType<typeof Bun.serve>
     try {
       server = Bun.serve({ port: preferred, hostname, fetch: handler })
-    } catch {
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'EADDRINUSE') throw err
       server = Bun.serve({ port: 0, hostname, fetch: handler })
     }
     this.printStartup(config, server.port ?? preferred)
@@ -85,7 +86,8 @@ export class LocalAdapter implements DeploymentAdapter {
     let server
     try {
       server = DenoNs.serve({ port: preferred, hostname }, handler)
-    } catch {
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'EADDRINUSE') throw err
       server = DenoNs.serve({ port: 0, hostname }, handler)
     }
 
@@ -159,11 +161,11 @@ export class LocalAdapter implements DeploymentAdapter {
         if (err.code === 'EADDRINUSE') {
           // Remove this error listener, retry with port 0
           server.removeAllListeners('error')
+          server.on('error', reject)
           server.listen(0, hostname, () => {
             const addr = server.address()
             resolve(typeof addr === 'object' && addr != null ? addr.port : preferred)
           })
-          server.on('error', reject)
         } else {
           reject(err)
         }
@@ -189,7 +191,7 @@ export class LocalAdapter implements DeploymentAdapter {
     console.log(`▌▌▌▛▖▙▌▌▌▄▌▌▐▖▙▖${RESET}`)
     console.log('')
     console.log(`  ${BOLD_GREEN}\u2192 ${url}${RESET}`)
-    if (actualPort !== config.server.port) {
+    if (config.server.port !== 0 && actualPort !== config.server.port) {
       console.log(`  ${DIM}Port ${String(config.server.port)} was in use, using ${String(actualPort)}${RESET}`)
     }
     console.log('')

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -149,12 +149,12 @@ export class LocalAdapter implements DeploymentAdapter {
   /**
    * Try preferred port; on EADDRINUSE, let the OS pick one.
    */
-  private listenOnPort (
+  private async listenOnPort (
     server: import('node:http').Server,
     preferred: number,
     hostname: string
   ): Promise<number> {
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       server.once('error', (err: NodeJS.ErrnoException) => {
         if (err.code === 'EADDRINUSE') {
           // Remove this error listener, retry with port 0

--- a/test/local-adapter-port-fallback.test.ts
+++ b/test/local-adapter-port-fallback.test.ts
@@ -1,0 +1,136 @@
+import {
+  describe,
+  it,
+  expect,
+  spyOn,
+  beforeEach,
+  afterEach,
+  type Mock
+} from 'bun:test'
+import { createServer, type Server } from 'node:http'
+import { LocalAdapter } from '../src/adapters/local.ts'
+import { resolveConfig } from '../src/config/defaults.ts'
+import type { MkdnSiteConfig } from '../src/config/schema.ts'
+
+/**
+ * Common shape for any LocalAdapter `start*` method — async or sync.
+ * Used so the same assertion can drive `start()` (Bun branch under bun test)
+ * and the private `startNode()` accessed via cast.
+ */
+type StartFn = (
+  handler: (request: Request) => Promise<Response>,
+  config: MkdnSiteConfig
+) => Promise<() => void> | (() => void)
+
+const handler = async (): Promise<Response> => new Response('ok')
+
+/** Bind a TCP server on an OS-chosen port so we can treat that port as occupied. */
+async function occupyPort (): Promise<{ port: number, release: () => void }> {
+  return await new Promise((resolve) => {
+    const blocker: Server = createServer()
+    blocker.listen(0, '127.0.0.1', () => {
+      const addr = blocker.address()
+      const port = typeof addr === 'object' && addr != null ? addr.port : 0
+      resolve({ port, release: () => { blocker.close() } })
+    })
+  })
+}
+
+/** Reconstruct the captured banner from a console.log spy. */
+function bannerFromSpy (spy: Mock<typeof console.log>): string {
+  const calls = spy.mock.calls as unknown[][]
+  return calls.map((args) => args.map((a) => String(a)).join(' ')).join('\n')
+}
+
+describe('LocalAdapter — port fallback', () => {
+  // spyOn + mockImplementation captures calls without polluting test output,
+  // and beforeEach/afterEach scope the spy to a single test. JS test runners
+  // (Jest, Vitest, Bun) run tests within a file sequentially and parallelize
+  // at the file level — so this pattern stays safe even if/when Bun moves to
+  // parallel test execution.
+  let logSpy: Mock<typeof console.log>
+
+  beforeEach(() => {
+    logSpy = spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+  })
+
+  /** Shared fallback assertion for any start* variant on LocalAdapter. */
+  async function assertFallback (startFn: StartFn, blockedPort: number): Promise<void> {
+    const config = resolveConfig({
+      contentDir: './content',
+      server: { port: blockedPort, hostname: '127.0.0.1' }
+    })
+
+    const stop = await Promise.resolve(startFn(handler, config))
+    try {
+      const banner = bannerFromSpy(logSpy)
+
+      // The notice line must mention the original (occupied) port.
+      expect(banner).toContain(`Port ${String(blockedPort)} was in use`)
+
+      // Recover the actual bound port from the printed URL.
+      const match = /http:\/\/localhost:(\d+)/.exec(banner)
+      expect(match).not.toBeNull()
+      const actualPort = Number(match?.[1])
+      expect(actualPort).toBeGreaterThan(0)
+      expect(actualPort).not.toBe(blockedPort)
+
+      // Prove the server is genuinely listening on the new port.
+      const res = await fetch(`http://127.0.0.1:${String(actualPort)}/`)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('ok')
+    } finally {
+      stop()
+    }
+  }
+
+  it('falls back via public start() (exercises the Bun branch under bun test)', async () => {
+    const { port, release } = await occupyPort()
+    try {
+      const adapter = new LocalAdapter()
+      await assertFallback(adapter.start.bind(adapter), port)
+    } finally {
+      release()
+    }
+  })
+
+  it('falls back via startNode() (exercises the EADDRINUSE retry path)', async () => {
+    const { port, release } = await occupyPort()
+    try {
+      const adapter = new LocalAdapter()
+      // startNode is private; cast through unknown for type-safe direct access.
+      const startNode = (adapter as unknown as {
+        startNode: StartFn
+      }).startNode.bind(adapter)
+      await assertFallback(startNode, port)
+    } finally {
+      release()
+    }
+  })
+
+  it('uses the configured port when it is free', async () => {
+    // Briefly occupy and release a port to learn a free one.
+    // (Tiny TOCTOU window, acceptable for a smoke test.)
+    const { port, release } = await occupyPort()
+    release()
+
+    const adapter = new LocalAdapter()
+    const config = resolveConfig({
+      contentDir: './content',
+      server: { port, hostname: '127.0.0.1' }
+    })
+
+    const stop = await adapter.start(handler, config)
+    try {
+      const banner = bannerFromSpy(logSpy)
+      expect(banner).toContain(`http://localhost:${String(port)}`)
+      expect(banner).not.toContain('was in use')
+    } finally {
+      stop()
+    }
+  })
+})


### PR DESCRIPTION
Closes #112. Supersedes #113 — thanks @xihale for the original contribution and review iteration!

## What this PR does

When the configured port is already in use, the local server now falls back to an OS-assigned random port (`port: 0`) instead of crashing, with a small notice in the startup banner indicating the fallback. Implemented across all three local runtimes (Bun, Deno, Node).

## Relationship to #113

This PR keeps **all three of @xihale's src-side commits intact** (preserved authorship + commit messages):

- `a86b58f` feat: fallback to random port when preferred port is occupied
- `0fa4c73` fix: make `listenOnPort` async to satisfy `promise-function-async` lint rule
- `191dcc8` fix: narrow port-fallback catch to `EADDRINUSE` only, reorder `listenOnPort` error listener

What changed vs #113: the `test/port-fallback.smoke.ts` cross-runtime smoke script + three per-runtime CI steps are replaced with a single `bun test` file that covers more ground in fewer moving parts.

## Why a `bun test` file instead of a smoke script

- **Covers both the Bun and Node branches in-process, in one job.** The new test calls the public `start()` (which under `bun test` exercises the Bun branch) *and* invokes `startNode()` directly via an `unknown` cast to exercise the `EADDRINUSE` retry path — the trickiest code in the change. With the smoke-script approach a Node-side regression wouldn't surface until the Node CI job ran separately in the matrix.
- **Adds a happy-path assertion.** Confirms the configured port is used directly when free, so a regression that always falls back would fail the suite.
- **Asserts the user-facing notice text** (`Port N was in use, using M`), not just that *some* different port appeared in the output.
- **Integrates with the existing test runner.** Reporter, discovery, watch mode, and aggregation all work — no one-off invocation pattern.
- **Uses `spyOn` + `beforeEach`/`afterEach`** rather than monkey-patching `console.log`, keeping the pattern safe under any future test-level concurrency in `bun:test`.

The Deno branch is small (8 lines, structurally identical to Bun's) and is not exercised by `bun test`. Trade-off accepted: code review covers it, and the `cli.ts --help` Deno CI job continues to confirm the module graph still loads under Deno.

## Verification

```
$ bun run lint     # passes
$ bun run tsc      # passes
$ bun test         # 530 pass, 0 fail (3 new tests, 14 new expects)
```
